### PR TITLE
prettier JSON output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Usage
     Options:
       -a, --auth TEXT         Path to Google credentials JSON file.
       --run / --test          --test simply prints the query.
-      -j, --json PATH         Desired path to JSON file.
+      -j, --json              Print data as JSON.
       -t, --timeout INTEGER   Milliseconds. Default: 120000 (2 minutes)
       -l, --limit TEXT        Maximum number of query results. Default: 20
       -d, --days TEXT         Number of days in the past to include. Default: 30
@@ -60,6 +60,7 @@ Usage
       -ed, --end-date TEXT    Must be negative. Default: -1
       -w, --where TEXT        WHERE conditional. Default: file.project = "project"
       -o, --order TEXT        Field to order by. Default: download_count
+      --version               Show the version and exit.
       --help                  Show this message and exit.
 
 pypinfo accepts 0 or more options, followed by exactly 1 project, followed by

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -1,8 +1,6 @@
-from json import dump
-
 import click
 
-from pypinfo.core import build_query, create_client, parse_query_result, tabulate
+from pypinfo.core import build_query, create_client, format_json, parse_query_result, tabulate
 from pypinfo.db import get_credentials, set_credentials
 from pypinfo.fields import (
     Project, Date, Month, Year, Country, Version, PythonVersion, Percent3,
@@ -43,7 +41,7 @@ FIELD_MAP = {
 @click.argument('fields', nargs=-1, required=False)
 @click.option('--auth', '-a', help='Path to Google credentials JSON file.')
 @click.option('--run/--test', default=True, help='--test simply prints the query.')
-@click.option('--json', '-j', type=click.Path(), help='Desired path to JSON file.')
+@click.option('--json', '-j', is_flag=True, help='Print data as JSON.')
 @click.option('--timeout', '-t', type=int, default=120000,
               help='Milliseconds. Default: 120000 (2 minutes)')
 @click.option('--limit', '-l', help='Maximum number of query results. Default: 20')
@@ -92,7 +90,6 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
         if not json:
             click.echo(tabulate(rows))
         else:
-            with open(json, 'w') as f:
-                dump(rows, f)
+            click.echo(format_json(rows))
     else:
         click.echo(built_query)

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -104,3 +104,18 @@ def tabulate(rows):
         tabulated += '\n'
 
     return tabulated
+
+
+def format_json(rows):
+    headers, *data = rows
+    j = []
+
+    for d in data:
+        item = {}
+        for i in range(len(headers)):
+            if d[i].isdigit():
+                d[i] = int(d[i])
+            item[headers[i]] = d[i]
+        j.append(item)
+
+    return json.dumps(j, indent=2, sort_keys=True)


### PR DESCRIPTION
I changed the `--json` option to just be a flag to set the output format. Users can still write the data to a file: `pypinfo --json requests pyversion > data.json`. This is more flexible if users want to avoid writing to disk.

`pypinfo --json requests pyversion`
before:
```
[["python_version", "download_count"], ["2.7", "8627477"], ["3.5", "859432"], ["3.4", "523369"], ["3.6", "486931"], ["2.6", "357381"], ["None", "175019"], ["3.3", "38859"], ["3.7", "9676"], ["3.2", "6228"], ["1.17", "647"], ["2.5", "30"], ["2.4", "14"], ["3.1", "5"], ["3.0", "2"]]
```
after:
```
[
  {
    "download_count": 8627477,
    "python_version": "2.7"
  },
  {
    "download_count": 859432,
    "python_version": "3.5"
  },
  {
    "download_count": 523369,
    "python_version": "3.4"
  },
  {
    "download_count": 486931,
    "python_version": "3.6"
  },
  {
    "download_count": 357381,
    "python_version": "2.6"
  },
  {
    "download_count": 175019,
    "python_version": "None"
  },
  {
    "download_count": 38859,
    "python_version": "3.3"
  },
  {
    "download_count": 9676,
    "python_version": "3.7"
  },
  {
    "download_count": 6228,
    "python_version": "3.2"
  },
  {
    "download_count": 647,
    "python_version": "1.17"
  },
  {
    "download_count": 30,
    "python_version": "2.5"
  },
  {
    "download_count": 14,
    "python_version": "2.4"
  },
  {
    "download_count": 5,
    "python_version": "3.1"
  },
  {
    "download_count": 2,
    "python_version": "3.0"
  }
]
```

`pypinfo --json requests`:
before: `[["download_count"], ["11085070"]]`
after:
```
[
  {
    "download_count": 11085070
  }
]
```