### PR TITLE
Change --order argument parsing to use the fields from FIELD_MAP as named in "pypinfo --help"

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -77,8 +77,8 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
 
     built_query = build_query(
         project, parsed_fields, limit=limit, days=days, start_date=start_date,
-        end_date=end_date, where=where, order=(FIELD_MAP[order].name if order 
-                                               else order)
+        end_date=end_date, where=where, order=(FIELD_MAP[order].name if
+                                               order in FIELD_MAP else order)
     )
 
     if run:

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -77,7 +77,8 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
 
     built_query = build_query(
         project, parsed_fields, limit=limit, days=days, start_date=start_date,
-        end_date=end_date, where=where, order=order
+        end_date=end_date, where=where, order=(FIELD_MAP[order].name if order 
+                                               else order)
     )
 
     if run:


### PR DESCRIPTION
Previously, the field names passed to `order` had to be those of the actual BigQuery database, and not those displayed with `pypinfo --help`. Now the appropriate field substitution is made when the `order` argument is passed into `build_query`.