### PR TITLE
Add --thousands seperator for non-JSON output

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -50,10 +50,12 @@ FIELD_MAP = {
 @click.option('--end-date', '-ed', help='Must be negative. Default: -1')
 @click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
 @click.option('--order', '-o', help='Field to order by. Default: download_count')
+@click.option('--thousands', '-th', is_flag=True,
+              help='Add a thousands separator (ignored for JSON)')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
-            start_date, end_date, where, order):
+            start_date, end_date, where, order, thousands):
     """Valid fields are:\n
     project | version | pyversion | percent3 | percent2 | impl | impl-version |\n
     openssl | date | month | year | country | installer | installer-version |\n
@@ -90,7 +92,7 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
         rows = parse_query_result(query)
 
         if not json:
-            click.echo(tabulate(rows))
+            click.echo(tabulate(rows, thousands_seperator=thousands))
         else:
             click.echo(format_json(rows))
     else:

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -88,8 +88,14 @@ def parse_query_result(query):
     return rows
 
 
-def tabulate(rows):
+def tabulate(rows, thousands_seperator=False):
     column_widths = [0] * len(rows[0])
+
+    if thousands_seperator:
+        for r, row in enumerate(rows):
+            for c, col in enumerate(row):
+                if col.isdigit():
+                    rows[r][c] = "{:,}".format(int(col))
 
     # Get max width of each column
     for row in rows:


### PR DESCRIPTION
The output would be more readable with comma-separated thousands, so here's a new option:

```⌂65% [hugo:~/github/pypinfo] thousands-seperator* 1 ±
⌂84% [hugo:~/github/pypinfo] thousands-seperator* 1 ± pypinfo django pyversion
python_version download_count
-------------- --------------
2.7            611777
3.6            259357
3.5            200749
3.4            104585
None           97813
2.6            6318
3.7            2342
3.3            2106
3.2            365
2.4            11
1.17           10
2.5            8
3.1            1
2.1            1
```
```
⌂87% [hugo:~/github/pypinfo] thousands-seperator* 3s ± pypinfo -th django pyversion
python_version download_count
-------------- --------------
2.7            611,777
3.6            259,357
3.5            200,749
3.4            104,585
None           97,813
2.6            6,318
3.7            2,342
3.3            2,106
3.2            365
2.4            11
1.17           10
2.5            8
3.1            1
2.1            1
```