### PR TITLE
Add --pip to only show installs by pip

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -50,10 +50,11 @@ FIELD_MAP = {
 @click.option('--end-date', '-ed', help='Must be negative. Default: -1')
 @click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
 @click.option('--order', '-o', help='Field to order by. Default: download_count')
+@click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
-            start_date, end_date, where, order):
+            start_date, end_date, where, order, pip):
     """Valid fields are:\n
     project | version | pyversion | percent3 | percent2 | impl | impl-version |\n
     openssl | date | month | year | country | installer | installer-version |\n
@@ -78,7 +79,8 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
     built_query = build_query(
         project, parsed_fields, limit=limit, days=days, start_date=start_date,
         end_date=end_date, where=where, order=(FIELD_MAP[order].name if
-                                               order in FIELD_MAP else order)
+                                               order in FIELD_MAP else order),
+        pip=pip
     )
 
     if run:

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -35,7 +35,7 @@ def create_client(creds_file=None):
 
 
 def build_query(project, fields, start_date=None, end_date=None,
-                days=None, limit=None, where=None, order=None):
+                days=None, limit=None, where=None, order=None, pip=None):
     project = normalize(project)
 
     start_date = start_date or START_DATE
@@ -62,8 +62,13 @@ def build_query(project, fields, start_date=None, end_date=None,
     if where:
         query += 'WHERE\n  {}\n'.format(where)
     else:
+        conditions = []
         if project:
-            query += 'WHERE\n  file.project = "{}"\n'.format(project)
+            conditions.append('file.project = "{}"\n'.format(project))
+        if pip:
+            conditions.append('details.installer.name = "pip"\n')
+        if conditions:
+            query += 'WHERE\n  ' + '  AND '.join(conditions)
 
     if len(fields) > 1:
         gb = 'GROUP BY\n'


### PR DESCRIPTION
For https://github.com/ofek/pypinfo/issues/4.

Examples:

```
[hugo:~/github/pypinfo] pip-only-flag(+11/-4)+* 7s ± pypinfo Flask
download_count
--------------
2661234

[hugo:~/github/pypinfo] pip-only-flag(+11/-4)+* 8s ± pypinfo Flask installer
installer_name download_count
-------------- --------------
pip            2575982
setuptools     52362
None           15351
pex            5518
requests       4471
Browser        3707
bandersnatch   2066
devpi          946
Artifactory    322
distribute     282
OS             181
Homebrew       23
conda          23

[hugo:~/github/pypinfo] pip-only-flag(+11/-4)+* 6s ± pypinfo --pip Flask installer
installer_name download_count
-------------- --------------
pip            2575982

[hugo:~/github/pypinfo] pip-only-flag(+11/-4)+* 6s ± pypinfo --pip Flask
download_count
--------------
2575982

hugo:~/github/pypinfo] pip-only-flag+* 7s 1 ± pypinfo ""
download_count
--------------
765826772

[hugo:~/github/pypinfo] pip-only-flag+* 24s ± pypinfo --pip ""
download_count
--------------
633312182
```