### PR TITLE
Do basic tests on the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 language: python
 
-matrix:
-    include:
-        - python: 3.5
-          env: TOXENV=py35
-        - python: 3.6
-          env: TOXENV=py36
-        - python: pypy3
-          env: TOXENV=pypy3
+python:
+ - pypy3
+ - 3.6
+ - 3.5
+
+sudo: false
 
 install:
-  - pip install tox
-  - pip install codecov
+ - pip install pyflakes pycodestyle
 
-script: "tox -- -rs"
+script:
+ # Static analysis
+ - pyflakes .
+ - pycodestyle --statistics --count .
 
-after_success:
-  - codecov
+ # Test install
+ - pip install -e .
+
+ # Simple offline test runs
+ - pypinfo --version
+ - pypinfo --help
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script:
  # Test install
  - pip install -e .
 
+ # For info
+ - pip freeze
+
  # Simple offline test runs
  - pypinfo --version
  - pypinfo --help

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -43,16 +43,21 @@ FIELD_MAP = {
 @click.argument('project', required=False)
 @click.argument('fields', nargs=-1, required=False)
 @click.option('--auth', '-a', help='Path to Google credentials JSON file.')
-@click.option('--run/--test', default=True, help='--test simply prints the query.')
+@click.option('--run/--test', default=True,
+              help='--test simply prints the query.')
 @click.option('--json', '-j', is_flag=True, help='Print data as JSON.')
 @click.option('--timeout', '-t', type=int, default=120000,
               help='Milliseconds. Default: 120000 (2 minutes)')
-@click.option('--limit', '-l', help='Maximum number of query results. Default: 20')
-@click.option('--days', '-d', help='Number of days in the past to include. Default: 30')
+@click.option('--limit', '-l',
+              help='Maximum number of query results. Default: 20')
+@click.option('--days', '-d',
+              help='Number of days in the past to include. Default: 30')
 @click.option('--start-date', '-sd', help='Must be negative. Default: -31')
 @click.option('--end-date', '-ed', help='Must be negative. Default: -1')
-@click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
-@click.option('--order', '-o', help='Field to order by. Default: download_count')
+@click.option('--where', '-w',
+              help='WHERE conditional. Default: file.project = "project"')
+@click.option('--order', '-o',
+              help='Field to order by. Default: download_count')
 @click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
 @click.version_option()
@@ -60,13 +65,15 @@ FIELD_MAP = {
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
             start_date, end_date, where, order, pip, percent):
     """Valid fields are:\n
-    project | version | pyversion | percent3 | percent2 | impl | impl-version |\n
-    openssl | date | month | year | country | installer | installer-version |\n
-    setuptools-version | system | system-release | distro | distro-version | cpu
+    project | version | pyversion | percent3 | percent2 | impl |\n
+    impl-version |openssl | date | month | year | country | installer |\n
+    installer-version | setuptools-version | system | system-release | distro |
+    distro-version | cpu
     """
     if auth:
         set_credentials(auth)
-        click.echo('Credentials location set to "{}".'.format(get_credentials()))
+        click.echo(
+            'Credentials location set to "{}".'.format(get_credentials()))
         return
 
     if project is None and not fields:

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -137,7 +137,8 @@ def tabulate(rows):
     for i, item in enumerate(headers):
         tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += '\n| ' + ''.join('-' * i + ' | ' for i in column_widths) + '\n'
+    tabulated += ('\n| ' + ''.join('-' * i + ' | ' for i in column_widths) +
+                  '\n')
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):

--- a/pypinfo/fields.py
+++ b/pypinfo/fields.py
@@ -8,18 +8,26 @@ Year = Field('download_year', 'STRFTIME_UTC_USEC(timestamp, "%Y")')
 Country = Field('country', 'country_code')
 Project = Field('project', 'file.project')
 Version = Field('version', 'file.version')
-PythonVersion = Field('python_version', 'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
+PythonVersion = Field(
+    'python_version',
+    'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
 Percent3 = Field(
     'percent_3',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "3" THEN 1 ELSE 0 END) / COUNT(*), 1)'
+    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = '
+    '"3" THEN 1 ELSE 0 END) / COUNT(*), 1)'
 )
 Percent2 = Field(
     'percent_2',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "2" THEN 1 ELSE 0 END) / COUNT(*), 1)'
+    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = '
+    '"2" THEN 1 ELSE 0 END) / COUNT(*), 1)'
 )
 Implementation = Field('implementation', 'details.implementation.name')
-ImplementationVersion = Field('impl_version', 'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
-OpenSSLVersion = Field('openssl_version', 'REGEXP_EXTRACT(details.openssl_version, r"^OpenSSL ([^ ]+) ")')
+ImplementationVersion = Field(
+    'impl_version',
+    'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
+OpenSSLVersion = Field(
+    'openssl_version',
+    'REGEXP_EXTRACT(details.openssl_version, r"^OpenSSL ([^ ]+) ")')
 Installer = Field('installer_name', 'details.installer.name')
 InstallerVersion = Field('installer_version', 'details.installer.version')
 SetuptoolsVersion = Field('setuptools_version', 'details.setuptools_version')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     ),
 
     python_requires='>=3.5',
-    install_requires=('appdirs', 'click', 'google-cloud-bigquery>=0.29.0', 'tinydb', 'tinyrecord'),
+    install_requires=('appdirs', 'click', 'google-cloud-bigquery>=0.29.0',
+                      'tinydb', 'tinyrecord'),
     tests_require=['pytest'],
 
     packages=find_packages(),


### PR DESCRIPTION
Whist testing against live BigQuery may prove expensive, we can easily use a CI for testing some basic things like correct syntax, installation and basic test runs.

Example output: https://travis-ci.org/hugovk/pypinfo/builds/288963281

---

Whilst live tests against BigQuery is not advisable (financially or from a "pure" unit test perspective), it's possible to mock the calls and their returns. I've not used it, but [VCR.py](https://github.com/kevin1024/vcrpy) looks useful. Anyway, one step at a time.