### PR TITLE
Output table in Markdown

### DIFF
--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -131,22 +131,25 @@ def tabulate(rows):
             if length > column_widths[i]:
                 column_widths[i] = length
 
-    tabulated = ''
+    tabulated = '| '
 
     headers = rows.pop(0)
     for i, item in enumerate(headers):
-        tabulated += item + ' ' * (column_widths[i] - len(item) + 1)
+        tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += '\n' + ''.join('-' * i + ' ' for i in column_widths) + '\n'
+    tabulated += '\n| ' + \
+                 ''.join('-' * i + ' | ' for i in column_widths) + \
+                 '\n'
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):
             num_spaces = column_widths[i] - len(item)
+            tabulated += '| '
             if is_digits[r][i] or item.endswith('%'):
                 tabulated += ' ' * num_spaces + item + ' '
             else:
                 tabulated += item + ' ' * (num_spaces + 1)
-        tabulated += '\n'
+        tabulated += '|\n'
 
     return tabulated
 

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -137,9 +137,7 @@ def tabulate(rows):
     for i, item in enumerate(headers):
         tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += '\n| ' + \
-                 ''.join('-' * i + ' | ' for i in column_widths) + \
-                 '\n'
+    tabulated += '\n| ' + ''.join('-' * i + ' | ' for i in column_widths) + '\n'
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):


### PR DESCRIPTION
A common use-case for me is using the stats in issues and PRs on GitHub. I've been pasting using code formatting, but it's straightforward to output using [Markdown](https://help.github.com/articles/organizing-information-with-tables/): it looks about the same on the console and much better in GitHub.

Here are examples using `pypinfo --percent --pip -d 1 pypinfo system`.

## Before (with code formatting):
```
system_name percent download_count
----------- ------- --------------
Linux         50.0%              2
Darwin        25.0%              1
Windows       25.0%              1
```

## Before (with GitHub Markdown):

system_name percent download_count
----------- ------- --------------
Linux         50.0%              2
Darwin        25.0%              1
Windows       25.0%              1

## After (with code formatting):
```
| system_name | percent | download_count |
| ----------- | ------- | -------------- |
| Linux       |   50.0% |              2 |
| Windows     |   25.0% |              1 |
| Darwin      |   25.0% |              1 |
```

## After (with GitHub Markdown):

| system_name | percent | download_count |
| ----------- | ------- | -------------- |
| Linux       |   50.0% |              2 |
| Windows     |   25.0% |              1 |
| Darwin      |   25.0% |              1 |