### PR TITLE
Right-align Markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 language: python
 
-matrix:
-    include:
-        - python: 3.5
-          env: TOXENV=py35
-        - python: 3.6
-          env: TOXENV=py36
-        - python: pypy3
-          env: TOXENV=pypy3
+python:
+ - pypy3
+ - 3.6
+ - 3.5
+
+sudo: false
 
 install:
-  - pip install tox
-  - pip install codecov
+ - pip install pyflakes pycodestyle
 
-script: "tox -- -rs"
+script:
+ # Static analysis
+ - pyflakes .
+ - pycodestyle --statistics --count .
 
-after_success:
-  - codecov
+ # Test install
+ - pip install -e .
+
+ # Simple offline test runs
+ - pypinfo --version
+ - pypinfo --help
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script:
  # Test install
  - pip install -e .
 
+ # For info
+ - pip freeze
+
  # Simple offline test runs
  - pypinfo --version
  - pypinfo --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 sudo: false
 
 install:
- - pip install pyflakes pycodestyle
+ - pip install pyflakes pycodestyle pytest
 
 script:
  # Static analysis
@@ -26,7 +26,7 @@ script:
  - pypinfo --help
 
  # Unit tests
- - python tests/test_core.py
+ - pytest
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,8 @@ script:
  - pypinfo --version
  - pypinfo --help
 
+ # Unit tests
+ - python tests/test_core.py
+
 matrix:
   fast_finish: true

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -60,10 +60,11 @@ FIELD_MAP = {
               help='Field to order by. Default: download_count')
 @click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
+@click.option('--markdown', '-md', is_flag=True, help='Output as Markdown.')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
-            start_date, end_date, where, order, pip, percent):
+            start_date, end_date, where, order, pip, percent, markdown):
     """Valid fields are:\n
     project | version | pyversion | percent3 | percent2 | impl |\n
     impl-version |openssl | date | month | year | country | installer |\n
@@ -105,7 +106,7 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
             rows = add_percentages(rows, include_sign=not json)
 
         if not json:
-            click.echo(tabulate(rows))
+            click.echo(tabulate(rows, markdown))
         else:
             click.echo(format_json(rows))
     else:

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -43,16 +43,21 @@ FIELD_MAP = {
 @click.argument('project', required=False)
 @click.argument('fields', nargs=-1, required=False)
 @click.option('--auth', '-a', help='Path to Google credentials JSON file.')
-@click.option('--run/--test', default=True, help='--test simply prints the query.')
+@click.option('--run/--test', default=True,
+              help='--test simply prints the query.')
 @click.option('--json', '-j', is_flag=True, help='Print data as JSON.')
 @click.option('--timeout', '-t', type=int, default=120000,
               help='Milliseconds. Default: 120000 (2 minutes)')
-@click.option('--limit', '-l', help='Maximum number of query results. Default: 20')
-@click.option('--days', '-d', help='Number of days in the past to include. Default: 30')
+@click.option('--limit', '-l',
+              help='Maximum number of query results. Default: 20')
+@click.option('--days', '-d',
+              help='Number of days in the past to include. Default: 30')
 @click.option('--start-date', '-sd', help='Must be negative. Default: -31')
 @click.option('--end-date', '-ed', help='Must be negative. Default: -1')
-@click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
-@click.option('--order', '-o', help='Field to order by. Default: download_count')
+@click.option('--where', '-w',
+              help='WHERE conditional. Default: file.project = "project"')
+@click.option('--order', '-o',
+              help='Field to order by. Default: download_count')
 @click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
 @click.version_option()
@@ -60,13 +65,15 @@ FIELD_MAP = {
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
             start_date, end_date, where, order, pip, percent):
     """Valid fields are:\n
-    project | version | pyversion | percent3 | percent2 | impl | impl-version |\n
-    openssl | date | month | year | country | installer | installer-version |\n
-    setuptools-version | system | system-release | distro | distro-version | cpu
+    project | version | pyversion | percent3 | percent2 | impl |\n
+    impl-version |openssl | date | month | year | country | installer |\n
+    installer-version | setuptools-version | system | system-release | distro |
+    distro-version | cpu
     """
     if auth:
         set_credentials(auth)
-        click.echo('Credentials location set to "{}".'.format(get_credentials()))
+        click.echo(
+            'Credentials location set to "{}".'.format(get_credentials()))
         return
 
     if project is None and not fields:

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -137,7 +137,8 @@ def tabulate(rows):
     for i, item in enumerate(headers):
         tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += '\n| ' + ''.join('-' * i + ' | ' for i in column_widths) + '\n'
+    tabulated += ('\n| ' + ''.join('-' * i + ' | ' for i in column_widths) +
+                  '\n')
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -118,7 +118,7 @@ def add_percentages(rows, include_sign=True):
 
 def tabulate(rows):
     column_widths = [0] * len(rows[0])
-    is_digits = [[False] * len(rows[0])] * len(rows)
+    right_align = [[False] * len(rows[0])] * len(rows)
 
     # Get max width of each column
     for r, row in enumerate(rows):
@@ -126,7 +126,9 @@ def tabulate(rows):
             if item.isdigit():
                 # Separate the thousands
                 rows[r][i] = "{:,}".format(int(item))
-                is_digits[r][i] = True
+                right_align[r][i] = True
+            elif item.endswith('%'):
+                right_align[r][i] = True
             length = len(item)
             if length > column_widths[i]:
                 column_widths[i] = length
@@ -144,7 +146,7 @@ def tabulate(rows):
         for i, item in enumerate(row):
             num_spaces = column_widths[i] - len(item)
             tabulated += '| '
-            if is_digits[r][i] or item.endswith('%'):
+            if right_align[r][i]:
                 tabulated += ' ' * num_spaces + item + ' '
             else:
                 tabulated += item + ' ' * (num_spaces + 1)

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -116,7 +116,7 @@ def add_percentages(rows, include_sign=True):
     return rows
 
 
-def tabulate(rows):
+def tabulate(rows, markdown=False):
     column_widths = [0] * len(rows[0])
     right_align = [[False] * len(rows[0])] * len(rows)
 
@@ -144,7 +144,7 @@ def tabulate(rows):
 
     for i, item in enumerate(rows[0]):
         tabulated += '-' * (column_widths[i]-1)
-        if right_align[0][i]:
+        if right_align[0][i] and markdown:
             tabulated += ': | '
         else:
             tabulated += '- | '

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -139,8 +139,18 @@ def tabulate(rows):
     for i, item in enumerate(headers):
         tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += ('\n| ' + ''.join('-' * i + ' | ' for i in column_widths) +
-                  '\n')
+    tabulated = tabulated.rstrip()
+    tabulated += '\n| '
+
+    for i, item in enumerate(rows[0]):
+        tabulated += '-' * (column_widths[i]-1)
+        if right_align[0][i]:
+            tabulated += ': | '
+        else:
+            tabulated += '- | '
+
+    tabulated = tabulated.rstrip()
+    tabulated += '\n'
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):

--- a/pypinfo/fields.py
+++ b/pypinfo/fields.py
@@ -8,18 +8,26 @@ Year = Field('download_year', 'STRFTIME_UTC_USEC(timestamp, "%Y")')
 Country = Field('country', 'country_code')
 Project = Field('project', 'file.project')
 Version = Field('version', 'file.version')
-PythonVersion = Field('python_version', 'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
+PythonVersion = Field(
+    'python_version',
+    'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
 Percent3 = Field(
     'percent_3',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "3" THEN 1 ELSE 0 END) / COUNT(*), 1)'
+    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = '
+    '"3" THEN 1 ELSE 0 END) / COUNT(*), 1)'
 )
 Percent2 = Field(
     'percent_2',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "2" THEN 1 ELSE 0 END) / COUNT(*), 1)'
+    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = '
+    '"2" THEN 1 ELSE 0 END) / COUNT(*), 1)'
 )
 Implementation = Field('implementation', 'details.implementation.name')
-ImplementationVersion = Field('impl_version', 'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
-OpenSSLVersion = Field('openssl_version', 'REGEXP_EXTRACT(details.openssl_version, r"^OpenSSL ([^ ]+) ")')
+ImplementationVersion = Field(
+    'impl_version',
+    'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
+OpenSSLVersion = Field(
+    'openssl_version',
+    'REGEXP_EXTRACT(details.openssl_version, r"^OpenSSL ([^ ]+) ")')
 Installer = Field('installer_name', 'details.installer.name')
 InstallerVersion = Field('installer_version', 'details.installer.version')
 SetuptoolsVersion = Field('setuptools_version', 'details.setuptools_version')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     ),
 
     python_requires='>=3.5',
-    install_requires=('appdirs', 'click', 'google-cloud-bigquery>=0.29.0', 'tinydb', 'tinyrecord'),
+    install_requires=('appdirs', 'click', 'google-cloud-bigquery>=0.29.0',
+                      'tinydb', 'tinyrecord'),
     tests_require=['pytest'],
 
     packages=find_packages(),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,32 +1,27 @@
-import unittest
-
 from pypinfo import core
 
 
-class TestCore(unittest.TestCase):
+def test_tabulate():
+    # Arrange
+    rows = [
+         ['python_version', 'percent', 'download_count'],
+         ['2.7', '51.7%', '342250'],
+         ['3.6', '21.1%', '139745'],
+         ['3.5', '17.2%', '114254'],
+         ['3.4', '7.6%', '50584'],
+         ['3.3', '1.0%', '6666'],
+         ['3.7', '0.7%', '4516'],
+         ['2.6', '0.7%', '4451'],
+         ['3.2', '0.0%', '138'],
+         ['None', '0.0%', '13']
+    ]
 
-    def test_tabulate(self):
-        # Arrange
-        self.maxDiff = None
-        rows = [
-             ['python_version', 'percent', 'download_count'],
-             ['2.7', '51.7%', '342250'],
-             ['3.6', '21.1%', '139745'],
-             ['3.5', '17.2%', '114254'],
-             ['3.4', '7.6%', '50584'],
-             ['3.3', '1.0%', '6666'],
-             ['3.7', '0.7%', '4516'],
-             ['2.6', '0.7%', '4451'],
-             ['3.2', '0.0%', '138'],
-             ['None', '0.0%', '13']
-        ]
+    # Act
+    tabulated = core.tabulate(rows)
+    print(tabulated)
 
-        # Act
-        tabulated = core.tabulate(rows)
-        print(tabulated)
-
-        # Assert
-        expected = """\
+    # Assert
+    expected = """\
 | python_version | percent | download_count |
 | -------------- | ------: | -------------: |
 | 2.7            |   51.7% |        342,250 |
@@ -39,8 +34,4 @@ class TestCore(unittest.TestCase):
 | 3.2            |    0.0% |            138 |
 | None           |    0.0% |             13 |
 """
-        self.assertEqual(tabulated, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    assert tabulated == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,8 +27,8 @@ class TestCore(unittest.TestCase):
 
         # Assert
         expected = """\
-| python_version | percent | download_count | 
-| -------------- | ------- | -------------- | 
+| python_version | percent | download_count |
+| -------------- | ------: | -------------: |
 | 2.7            |   51.7% |        342,250 |
 | 3.6            |   21.1% |        139,745 |
 | 3.5            |   17.2% |        114,254 |

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,26 +1,46 @@
 from pypinfo import core
 
+ROWS = [
+    ['python_version', 'percent', 'download_count'],
+    ['2.7', '51.7%', '342250'],
+    ['3.6', '21.1%', '139745'],
+    ['3.5', '17.2%', '114254'],
+    ['3.4', '7.6%', '50584'],
+    ['3.3', '1.0%', '6666'],
+    ['3.7', '0.7%', '4516'],
+    ['2.6', '0.7%', '4451'],
+    ['3.2', '0.0%', '138'],
+    ['None', '0.0%', '13']
+]
 
-def test_tabulate():
+
+def test_tabulate_default():
     # Arrange
-    rows = [
-         ['python_version', 'percent', 'download_count'],
-         ['2.7', '51.7%', '342250'],
-         ['3.6', '21.1%', '139745'],
-         ['3.5', '17.2%', '114254'],
-         ['3.4', '7.6%', '50584'],
-         ['3.3', '1.0%', '6666'],
-         ['3.7', '0.7%', '4516'],
-         ['2.6', '0.7%', '4451'],
-         ['3.2', '0.0%', '138'],
-         ['None', '0.0%', '13']
-    ]
+    rows = list(ROWS)
+    expected = """\
+| python_version | percent | download_count |
+| -------------- | ------- | -------------- |
+| 2.7            |   51.7% |        342,250 |
+| 3.6            |   21.1% |        139,745 |
+| 3.5            |   17.2% |        114,254 |
+| 3.4            |    7.6% |         50,584 |
+| 3.3            |    1.0% |          6,666 |
+| 3.7            |    0.7% |          4,516 |
+| 2.6            |    0.7% |          4,451 |
+| 3.2            |    0.0% |            138 |
+| None           |    0.0% |             13 |
+"""
 
     # Act
     tabulated = core.tabulate(rows)
-    print(tabulated)
 
     # Assert
+    assert tabulated == expected
+
+
+def test_tabulate_markdown():
+    # Arrange
+    rows = list(ROWS)
     expected = """\
 | python_version | percent | download_count |
 | -------------- | ------: | -------------: |
@@ -34,4 +54,9 @@ def test_tabulate():
 | 3.2            |    0.0% |            138 |
 | None           |    0.0% |             13 |
 """
+
+    # Act
+    tabulated = core.tabulate(rows, markdown=True)
+
+    # Assert
     assert tabulated == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,46 @@
+import unittest
+
+from pypinfo import core
+
+
+class TestCore(unittest.TestCase):
+
+    def test_tabulate(self):
+        # Arrange
+        self.maxDiff = None
+        rows = [
+             ['python_version', 'percent', 'download_count'],
+             ['2.7', '51.7%', '342250'],
+             ['3.6', '21.1%', '139745'],
+             ['3.5', '17.2%', '114254'],
+             ['3.4', '7.6%', '50584'],
+             ['3.3', '1.0%', '6666'],
+             ['3.7', '0.7%', '4516'],
+             ['2.6', '0.7%', '4451'],
+             ['3.2', '0.0%', '138'],
+             ['None', '0.0%', '13']
+        ]
+
+        # Act
+        tabulated = core.tabulate(rows)
+        print(tabulated)
+
+        # Assert
+        expected = """\
+| python_version | percent | download_count | 
+| -------------- | ------- | -------------- | 
+| 2.7            |   51.7% |        342,250 |
+| 3.6            |   21.1% |        139,745 |
+| 3.5            |   17.2% |        114,254 |
+| 3.4            |    7.6% |         50,584 |
+| 3.3            |    1.0% |          6,666 |
+| 3.7            |    0.7% |          4,516 |
+| 2.6            |    0.7% |          4,451 |
+| 3.2            |    0.0% |            138 |
+| None           |    0.0% |             13 |
+"""
+        self.assertEqual(tabulated, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Simply adding a colon will align columns nicely in Markdown.

See https://help.github.com/articles/organizing-information-with-tables/#formatting-content-within-your-table

Builds on #23 by including a unit test for this change ([eg.](https://travis-ci.org/hugovk/pypinfo/builds/312945563)). This makes things much easier to develop without going over your quota!

## Before

As plaintext:

```
| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |
```

As rendered Markdown:

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |

## After

As plaintext:

```
| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |
```

As rendered Markdown:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |

