### PR TITLE
Right-align Markdown

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -55,10 +55,11 @@ FIELD_MAP = {
 @click.option('--order', '-o', help='Field to order by. Default: download_count')
 @click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
+@click.option('--markdown', '-md', is_flag=True, help='Output as Markdown.')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
-            start_date, end_date, where, order, pip, percent):
+            start_date, end_date, where, order, pip, percent, markdown):
     """Valid fields are:\n
     project | version | pyversion | percent3 | percent2 | impl | impl-version |\n
     openssl | date | month | year | country | installer | installer-version |\n
@@ -98,7 +99,7 @@ def pypinfo(ctx, project, fields, auth, run, json, timeout, limit, days,
             rows = add_percentages(rows, include_sign=not json)
 
         if not json:
-            click.echo(tabulate(rows))
+            click.echo(tabulate(rows, markdown))
         else:
             click.echo(format_json(rows))
     else:

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -116,7 +116,7 @@ def add_percentages(rows, include_sign=True):
     return rows
 
 
-def tabulate(rows):
+def tabulate(rows, markdown=False):
     column_widths = [0] * len(rows[0])
     right_align = [[False] * len(rows[0])] * len(rows)
 
@@ -139,7 +139,18 @@ def tabulate(rows):
     for i, item in enumerate(headers):
         tabulated += item + ' | ' * (column_widths[i] - len(item) + 1)
 
-    tabulated += '\n| ' + ''.join('-' * i + ' | ' for i in column_widths) + '\n'
+    tabulated = tabulated.rstrip()
+    tabulated += '\n| '
+
+    for i, item in enumerate(rows[0]):
+        tabulated += '-' * (column_widths[i]-1)
+        if right_align[0][i] and markdown:
+            tabulated += ': | '
+        else:
+            tabulated += '- | '
+
+    tabulated = tabulated.rstrip()
+    tabulated += '\n'
 
     for r, row in enumerate(rows):
         for i, item in enumerate(row):

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -118,7 +118,7 @@ def add_percentages(rows, include_sign=True):
 
 def tabulate(rows):
     column_widths = [0] * len(rows[0])
-    is_digits = [[False] * len(rows[0])] * len(rows)
+    right_align = [[False] * len(rows[0])] * len(rows)
 
     # Get max width of each column
     for r, row in enumerate(rows):
@@ -126,7 +126,9 @@ def tabulate(rows):
             if item.isdigit():
                 # Separate the thousands
                 rows[r][i] = "{:,}".format(int(item))
-                is_digits[r][i] = True
+                right_align[r][i] = True
+            elif item.endswith('%'):
+                right_align[r][i] = True
             length = len(item)
             if length > column_widths[i]:
                 column_widths[i] = length
@@ -143,7 +145,7 @@ def tabulate(rows):
         for i, item in enumerate(row):
             num_spaces = column_widths[i] - len(item)
             tabulated += '| '
-            if is_digits[r][i] or item.endswith('%'):
+            if right_align[r][i]:
                 tabulated += ' ' * num_spaces + item + ' '
             else:
                 tabulated += item + ' ' * (num_spaces + 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,62 @@
+from pypinfo import core
+
+ROWS = [
+    ['python_version', 'percent', 'download_count'],
+    ['2.7', '51.7%', '342250'],
+    ['3.6', '21.1%', '139745'],
+    ['3.5', '17.2%', '114254'],
+    ['3.4', '7.6%', '50584'],
+    ['3.3', '1.0%', '6666'],
+    ['3.7', '0.7%', '4516'],
+    ['2.6', '0.7%', '4451'],
+    ['3.2', '0.0%', '138'],
+    ['None', '0.0%', '13']
+]
+
+
+def test_tabulate_default():
+    # Arrange
+    rows = list(ROWS)
+    expected = """\
+| python_version | percent | download_count |
+| -------------- | ------- | -------------- |
+| 2.7            |   51.7% |        342,250 |
+| 3.6            |   21.1% |        139,745 |
+| 3.5            |   17.2% |        114,254 |
+| 3.4            |    7.6% |         50,584 |
+| 3.3            |    1.0% |          6,666 |
+| 3.7            |    0.7% |          4,516 |
+| 2.6            |    0.7% |          4,451 |
+| 3.2            |    0.0% |            138 |
+| None           |    0.0% |             13 |
+"""
+
+    # Act
+    tabulated = core.tabulate(rows)
+
+    # Assert
+    assert tabulated == expected
+
+
+def test_tabulate_markdown():
+    # Arrange
+    rows = list(ROWS)
+    expected = """\
+| python_version | percent | download_count |
+| -------------- | ------: | -------------: |
+| 2.7            |   51.7% |        342,250 |
+| 3.6            |   21.1% |        139,745 |
+| 3.5            |   17.2% |        114,254 |
+| 3.4            |    7.6% |         50,584 |
+| 3.3            |    1.0% |          6,666 |
+| 3.7            |    0.7% |          4,516 |
+| 2.6            |    0.7% |          4,451 |
+| 3.2            |    0.0% |            138 |
+| None           |    0.0% |             13 |
+"""
+
+    # Act
+    tabulated = core.tabulate(rows, markdown=True)
+
+    # Assert
+    assert tabulated == expected


### PR DESCRIPTION
Like https://github.com/ofek/pypinfo/pull/33 but doesn't include Travis CI changes or flake8 stuff.

Simply adding a colon will align columns nicely in Markdown.

See https://help.github.com/articles/organizing-information-with-tables/#formatting-content-within-your-table

Includes a unit test for this option and the default behaviour, which makes things much easier to develop without going over your quota!

## Before

As plaintext:

```
| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |
```

As rendered Markdown:

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |

## After

As plaintext:

```
| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |
```

As rendered Markdown:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   59.3% |          3,048 |
| 3.5            |   20.9% |          1,074 |
| 3.6            |   14.3% |            734 |
| 3.4            |    5.4% |            279 |
| 2.6            |    0.1% |              4 |

