### PR TITLE
Add UTC timestamp to JSON

### DIFF
--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import re
@@ -184,7 +185,9 @@ def format_json(rows, query_info, indent):
             item[headers[i]] = d[i]
         rows.append(item)
 
-    j = {'rows': rows, 'query': query_info}
+    now = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+
+    j = {'last_update': now, 'rows': rows, 'query': query_info}
 
     separators = (',', ':') if indent is None else None
     return json.dumps(j, indent=indent, separators=separators, sort_keys=True)


### PR DESCRIPTION
As discussed in https://github.com/ofek/pypinfo/pull/41.

```
$ pypinfo --start-date -39 --end-date -9 --percent --pip --json --indent 2 pypinfo pyversion
{
  "last_update": "2018-02-09 06:45:58",
  "query": {
    "bytes_billed": 0,
    "bytes_processed": 0,
    "cached": true,
    "estimated_cost": "0.00"
  },
  "rows": [
    {
      "download_count": 78,
      "percent": "0.46",
      "python_version": "2.7"
    },
    {
      "download_count": 46,
      "percent": "0.27",
      "python_version": "3.6"
    },
    {
      "download_count": 42,
      "percent": "0.25",
      "python_version": "3.5"
    },
    {
      "download_count": 4,
      "percent": "0.024",
      "python_version": "3.4"
    }
  ]
}
```

```
$ pypinfo --start-date -39 --end-date -9 --percent --pip --markdown --indent 2 pypinfo pyversion
Served from cache: True
Data processed: 0.00 B
Data billed: 0.00 B
Estimated cost: $0.00

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  45.88% |             78 |
| 3.6            |  27.06% |             46 |
| 3.5            |  24.71% |             42 |
| 3.4            |   2.35% |              4 |
```