### PR TITLE
Add --all option, default to --pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /.cache
 /.idea
 /.coverage
+/.coverage.*
+/.pytest_cache
 /pypinfo.egg-info
 /build
 /dist

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -62,12 +62,15 @@ TO_CENTS = Decimal('0.00')
 @click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
 @click.option('--order', '-o', help='Field to order by. Default: download_count')
 @click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
+@click.option('--all', 'all_installers', is_flag=True,
+              help='Show downloads by all installers, not only pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
 @click.option('--markdown', '-md', is_flag=True, help='Output as Markdown.')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, indent, timeout, limit, days,
-            start_date, end_date, where, order, pip, percent, markdown):
+            start_date, end_date, where, order, pip, all_installers, percent,
+            markdown):
     """Valid fields are:\n
     project | version | file | pyversion | percent3 | percent2 | impl | impl-version |\n
     openssl | date | month | year | country | installer | installer-version |\n
@@ -94,6 +97,9 @@ def pypinfo(ctx, project, fields, auth, run, json, indent, timeout, limit, days,
     if order:
         order_name = order.name
         parsed_fields.insert(0, order)
+
+    if not pip:
+        pip = not all_installers
 
     built_query = build_query(
         project, parsed_fields, limit=limit, days=days, start_date=start_date,

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -61,7 +61,6 @@ TO_CENTS = Decimal('0.00')
 @click.option('--end-date', '-ed', help='Must be negative. Default: -1')
 @click.option('--where', '-w', help='WHERE conditional. Default: file.project = "project"')
 @click.option('--order', '-o', help='Field to order by. Default: download_count')
-@click.option('--pip', '-p', is_flag=True, help='Only show installs by pip.')
 @click.option('--all', 'all_installers', is_flag=True,
               help='Show downloads by all installers, not only pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
@@ -69,7 +68,7 @@ TO_CENTS = Decimal('0.00')
 @click.version_option()
 @click.pass_context
 def pypinfo(ctx, project, fields, auth, run, json, indent, timeout, limit, days,
-            start_date, end_date, where, order, pip, all_installers, percent,
+            start_date, end_date, where, order, all_installers, percent,
             markdown):
     """Valid fields are:\n
     project | version | file | pyversion | percent3 | percent2 | impl | impl-version |\n
@@ -98,12 +97,9 @@ def pypinfo(ctx, project, fields, auth, run, json, indent, timeout, limit, days,
         order_name = order.name
         parsed_fields.insert(0, order)
 
-    if not pip:
-        pip = not all_installers
-
     built_query = build_query(
         project, parsed_fields, limit=limit, days=days, start_date=start_date,
-        end_date=end_date, where=where, order=order_name, pip=pip
+        end_date=end_date, where=where, order=order_name, pip=not all_installers,
     )
 
     if run:


### PR DESCRIPTION
Fixes #46.

`--pip` is now the default behaviour, with a new `--all` to match the old default behaviour.

```console

$ # with --pip

$ pypinfo --pip requests installer
Served from cache: False
Data processed: 9.01 GiB
Data billed: 9.01 GiB
Estimated cost: $0.05

| installer_name | download_count |
| -------------- | -------------- |
| pip            |      7,454,395 |

$ # with --all

$ pypinfo --all requests installer
Served from cache: False
Data processed: 9.01 GiB
Data billed: 9.01 GiB
Estimated cost: $0.05

| installer_name | download_count |
| -------------- | -------------- |
| pip            |      7,454,395 |
| setuptools     |        141,246 |
| Browser        |         80,016 |
| pex            |         54,178 |
| None           |         27,808 |
| bandersnatch   |          8,351 |
| Homebrew       |          4,973 |
| OS             |          2,776 |
| requests       |          2,187 |
| devpi          |          1,632 |

$ # with neither, defaults to --pip

$ pypinfo requests installer
Served from cache: True
Data processed: 0.00 B
Data billed: 0.00 B
Estimated cost: $0.00

| installer_name | download_count |
| -------------- | -------------- |
| pip            |      7,454,395 |
```

Do we even need the `--pip` option?

It could perhaps be kept for backwards compatibility (for a release or two?), or just removed completely.
