### PR TITLE
Add download total

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -5,6 +5,7 @@ from binary import TEBIBYTE, convert_units
 
 from pypinfo.core import (
     add_percentages,
+    add_download_total,
     build_query,
     create_client,
     create_config,
@@ -168,6 +169,10 @@ def pypinfo(
 
         if percent:
             rows = add_percentages(rows, include_sign=not json)
+
+        # Only for tables, and if more than the header row + a single data row
+        if len(rows) > 2 and not json:
+            rows = add_download_total(rows)
 
         if not json:
             click.echo('Served from cache: {}'.format(from_cache))

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -160,6 +160,27 @@ def add_percentages(rows, include_sign=True):
     return rows
 
 
+def get_download_total(rows):
+    """Return the total downloads, and the downloads column"""
+    headers = rows.pop(0)
+    index = headers.index('download_count')
+    total_downloads = sum(int(row[index]) for row in rows)
+
+    rows.insert(0, headers)
+    return total_downloads, index
+
+
+def add_download_total(rows):
+    """Add a final row to rows showing the total downloads"""
+    total_row = [""] * len(rows[0])
+    total_row[0] = "Total"
+    total_downloads, downloads_column = get_download_total(rows)
+    total_row[downloads_column] = str(total_downloads)
+    rows.append(total_row)
+
+    return rows
+
+
 def tabulate(rows, markdown=False):
     column_widths = [0] * len(rows[0])
     right_align = [[False] * len(rows[0])] * len(rows)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,3 +153,17 @@ def test_add_percentages():
 
     # Assert
     assert with_percentages == expected
+
+
+def test_add_total():
+    # Arrange
+    rows = copy.deepcopy(ROWS)
+    expected = copy.deepcopy(ROWS)
+    expected.append(["Total", "", "662617"])
+
+    # Act
+    rows_with_total = core.add_download_total(rows)
+
+    # Assert
+    assert rows_with_total == expected
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -166,4 +166,3 @@ def test_add_total():
 
     # Assert
     assert rows_with_total == expected
-


### PR DESCRIPTION
## Add download total

Only if:
* not `--json`: we don't want this included in the JSON, 
* and more than one row of numbers: no need if only one row, as a single row already is the total
* and at least two columns: so there's somewhere to put "Total"

```console
$ pypinfo requests
Served from cache: False
Data processed: 8.64 GiB
Data billed: 8.64 GiB
Estimated cost: $0.05

| download_count |
| -------------- |
|      7,125,849 |

$ pypinfo requests pyversion
Served from cache: False
Data processed: 12.10 GiB
Data billed: 12.10 GiB
Estimated cost: $0.06

| python_version | download_count |
| -------------- | -------------- |
| 2.7            |      4,482,484 |
| 3.6            |      1,707,002 |
| 3.5            |        507,756 |
| 3.4            |        392,867 |
| 2.6            |         17,939 |
| 3.7            |         11,964 |
| 3.3            |          5,181 |
| 3.2            |            582 |
| None           |             57 |
| 3.8            |             15 |
| Total          |      7,125,847 |

$ pypinfo ""
Served from cache: False
Data processed: 3.12 GiB
Data billed: 3.12 GiB
Estimated cost: $0.02

| download_count |
| -------------- |
|    480,723,489 |

$ pypinfo django pyversion
Served from cache: False
Data processed: 12.10 GiB
Data billed: 12.10 GiB
Estimated cost: $0.06

| python_version | download_count |
| -------------- | -------------- |
| 3.6            |        292,406 |
| 3.5            |        287,988 |
| 2.7            |        268,271 |
| 3.4            |         38,534 |
| 3.7            |          2,645 |
| 2.6            |          1,039 |
| 3.3            |            541 |
| 3.2            |             91 |
| None           |              6 |
| 3.8            |              2 |
| Total          |        891,523 |

$ pypinfo "" country
Served from cache: False
Data processed: 5.13 GiB
Data billed: 5.13 GiB
Estimated cost: $0.03

| country | download_count |
| ------- | -------------- |
| US      |    320,977,121 |
| IE      |     25,734,733 |
| DE      |     12,541,709 |
| None    |     12,166,597 |
| JP      |     10,326,777 |
| GB      |      9,596,711 |
| CN      |      8,250,535 |
| CA      |      8,135,581 |
| AU      |      7,859,521 |
| SG      |      7,538,250 |
| Total   |    423,127,535 |

$ pypinfo cryptography system distro
Served from cache: False
Data processed: 15.80 GiB
Data billed: 15.80 GiB
Estimated cost: $0.08

| system_name | distro_name                     | download_count |
| ----------- | ------------------------------- | -------------- |
| Linux       | Ubuntu                          |      1,105,739 |
| Linux       | None                            |        757,605 |
| Linux       | Debian GNU/Linux                |        317,053 |
| Linux       | Amazon Linux AMI                |        189,015 |
| Linux       | CentOS Linux                    |        152,618 |
| Windows     | None                            |        138,929 |
| Darwin      | macOS                           |         55,451 |
| Linux       | CentOS                          |         38,130 |
| Linux       | Red Hat Enterprise Linux Server |         37,828 |
| Linux       | Alpine Linux                    |         37,528 |
| Total       |                                 |      2,829,896 |

```

## Same commands with --json

Total not included in JSON output.

```console
$ pypinfo --json requests
{"last_update":"2018-05-31 15:10:12","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"download_count":7125849}]}
$ pypinfo --json requests pyversion
{"last_update":"2018-05-31 15:10:28","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"download_count":4482484,"python_version":"2.7"},{"download_count":1707002,"python_version":"3.6"},{"download_count":507756,"python_version":"3.5"},{"download_count":392867,"python_version":"3.4"},{"download_count":17939,"python_version":"2.6"},{"download_count":11964,"python_version":"3.7"},{"download_count":5181,"python_version":"3.3"},{"download_count":582,"python_version":"3.2"},{"download_count":57,"python_version":"None"},{"download_count":15,"python_version":"3.8"}]}
$ pypinfo --json ""
{"last_update":"2018-05-31 15:10:55","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"download_count":480723489}]}
$ pypinfo --json django pyversion
{"last_update":"2018-05-31 15:11:11","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"download_count":292406,"python_version":"3.6"},{"download_count":287988,"python_version":"3.5"},{"download_count":268271,"python_version":"2.7"},{"download_count":38534,"python_version":"3.4"},{"download_count":2645,"python_version":"3.7"},{"download_count":1039,"python_version":"2.6"},{"download_count":541,"python_version":"3.3"},{"download_count":91,"python_version":"3.2"},{"download_count":6,"python_version":"None"},{"download_count":2,"python_version":"3.8"}]}
$ pypinfo --json "" country
{"last_update":"2018-05-31 15:11:26","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"country":"US","download_count":320977121},{"country":"IE","download_count":25734733},{"country":"DE","download_count":12541709},{"country":"None","download_count":12166597},{"country":"JP","download_count":10326777},{"country":"GB","download_count":9596711},{"country":"CN","download_count":8250535},{"country":"CA","download_count":8135581},{"country":"AU","download_count":7859521},{"country":"SG","download_count":7538250}]}
$ pypinfo --json cryptography system distro
{"last_update":"2018-05-31 15:12:29","query":{"bytes_billed":0,"bytes_processed":0,"cached":true,"estimated_cost":"0.00"},"rows":[{"distro_name":"Ubuntu","download_count":1105739,"system_name":"Linux"},{"distro_name":"None","download_count":757605,"system_name":"Linux"},{"distro_name":"Debian GNU/Linux","download_count":317053,"system_name":"Linux"},{"distro_name":"Amazon Linux AMI","download_count":189015,"system_name":"Linux"},{"distro_name":"CentOS Linux","download_count":152618,"system_name":"Linux"},{"distro_name":"None","download_count":138929,"system_name":"Windows"},{"distro_name":"macOS","download_count":55451,"system_name":"Darwin"},{"distro_name":"CentOS","download_count":38130,"system_name":"Linux"},{"distro_name":"Red Hat Enterprise Linux Server","download_count":37828,"system_name":"Linux"},{"distro_name":"Alpine Linux","download_count":37528,"system_name":"Linux"}]}
```
