### PR TITLE
Add .tox directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.coverage
 /.coverage.*
 /.pytest_cache
+/.tox
 /pypinfo.egg-info
 /build
 /dist


### PR DESCRIPTION
The directory is automatically generated by the tox command.