### PR TITLE
Fix W605 invalid escape sequence '\.'

### DIFF
--- a/pypinfo/fields.py
+++ b/pypinfo/fields.py
@@ -9,17 +9,17 @@ Country = Field('country', 'country_code')
 Project = Field('project', 'file.project')
 Version = Field('version', 'file.version')
 File = Field('file', 'file.filename')
-PythonVersion = Field('python_version', 'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
+PythonVersion = Field('python_version', r'REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)")')
 Percent3 = Field(
     'percent_3',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "3" THEN 1 ELSE 0 END) / COUNT(*), 1)',
+    r'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "3" THEN 1 ELSE 0 END) / COUNT(*), 1)',
 )
 Percent2 = Field(
     'percent_2',
-    'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "2" THEN 1 ELSE 0 END) / COUNT(*), 1)',
+    r'ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "2" THEN 1 ELSE 0 END) / COUNT(*), 1)',
 )
 Implementation = Field('implementation', 'details.implementation.name')
-ImplementationVersion = Field('impl_version', 'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
+ImplementationVersion = Field('impl_version', r'REGEXP_EXTRACT(details.implementation.version, r"^([^\.]+\.[^\.]+)")')
 OpenSSLVersion = Field('openssl_version', 'REGEXP_EXTRACT(details.openssl_version, r"^OpenSSL ([^ ]+) ")')
 Installer = Field('installer_name', 'details.installer.name')
 InstallerVersion = Field('installer_version', 'details.installer.version')


### PR DESCRIPTION
Flake8 has had a new release, with a new check which fails:

```
⌂86% [hugo:~/github/pypinfo] master+ ± flake8 .
./pypinfo/fields.py:12:39: W605 invalid escape sequence '\.'
./pypinfo/fields.py:12:43: W605 invalid escape sequence '\.'
./pypinfo/fields.py:12:47: W605 invalid escape sequence '\.'
./pypinfo/fields.py:15:39: W605 invalid escape sequence '\.'
./pypinfo/fields.py:19:39: W605 invalid escape sequence '\.'
./pypinfo/fields.py:22:55: W605 invalid escape sequence '\.'
./pypinfo/fields.py:22:59: W605 invalid escape sequence '\.'
./pypinfo/fields.py:22:63: W605 invalid escape sequence '\.'
```

This PR includes a fix to mark the strings as raw strings with `r""`.

I've not yet tested this locally as I'm out of BigQuery quota right now, but will do soon.