### PR TITLE
Improve tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 1.9
 envlist =
     py35,
     py36,
@@ -12,7 +13,6 @@ deps =
     coverage
     pytest
 commands =
-    python setup.py --quiet clean develop
     coverage run --parallel-mode -m pytest
     coverage combine --append
     coverage report -m
@@ -24,3 +24,4 @@ deps =
 commands =
     black --check --diff .
     flake8 .
+skip_install = true


### PR DESCRIPTION
Drop `python setup.py --quiet clean develop`. tox installs the package by default automatically. There is no need to do so explicitly. 

Add `skip_install` to the lint environment. There is no need to install the package to do static analysis. Slightly speeds up the command `tox -e lint`.

Add `minversion = 1.9` to support the `skip_install` option.

For full details on tox configuration, see:

https://tox.readthedocs.io/en/latest/config.html