### PR TITLE
Update Black URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ pypinfo: View PyPI download statistics with ease.
     :target: https://en.wikipedia.org/wiki/MIT_License
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square
-    :target: https://github.com/ambv/black
+    :target: https://github.com/python/black
 
 -----
 


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190