### PR TITLE
Add --verbose option to print credentials location

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -84,6 +84,7 @@ TO_CENTS = Decimal('0.00')
 @click.option('--all', 'all_installers', is_flag=True, help='Show downloads by all installers, not only pip.')
 @click.option('--percent', '-pc', is_flag=True, help='Print percentages.')
 @click.option('--markdown', '-md', is_flag=True, help='Output as Markdown.')
+@click.option('--verbose', '-v', is_flag=True, help='Print debug messages to stderr.')
 @click.version_option()
 @click.pass_context
 def pypinfo(
@@ -104,6 +105,7 @@ def pypinfo(
     all_installers,
     percent,
     markdown,
+    verbose,
 ):
     """Valid fields are:\n
     project | version | file | pyversion | percent3 | percent2 | impl | impl-version |\n
@@ -114,6 +116,9 @@ def pypinfo(
         set_credentials(auth)
         click.echo('Credentials location set to "{}".'.format(get_credentials()))
         return
+
+    if verbose:
+        click.echo('Credentials location set to "{}".'.format(get_credentials()), err=True)
 
     if project is None and not fields:
         click.echo(ctx.get_help())


### PR DESCRIPTION
Sometimes I need to check which actual credentials JSON file is being used, or where it is, so I can use another.

It'd be useful to have an option to print it out. This PR adds a `--verbose` option to print debug messages to stderr. At the moment, it only prints the creds file location, and can be used to add other debug messages in the future.

Example output:

```console
$ pypinfo --test --verbose pip file
Credentials location set to "/Users/hugo/bin/data/pypinfo.json".
SELECT
  file.filename as file,
  COUNT(*) as download_count,
FROM
  TABLE_DATE_RANGE(
    [the-psf:pypi.downloads],
    DATE_ADD(CURRENT_TIMESTAMP(), -31, "day"),
    DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")
  )
WHERE
  file.project = "pip"
  AND details.installer.name = "pip"
GROUP BY
  file,
ORDER BY
  download_count DESC
LIMIT 10
```

On a system with no creds file set yet:
```console
$ pypinfo --verbose pillow file
Credentials location set to "None".
Traceback (most recent call last):
  File "/usr/bin/pypinfo", line 11, in <module>
    load_entry_point('pypinfo', 'console_scripts', 'pypinfo')()
  File "/home/wodby/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/wodby/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/wodby/.local/lib/python3.6/site-packages/click/core.py", line 1114, in invoke
    return Command.invoke(self, ctx)
  File "/home/wodby/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/wodby/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/wodby/.local/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/tmp/pypinfo/pypinfo/cli.py", line 153, in pypinfo
    client = create_client(get_credentials())
  File "/tmp/pypinfo/pypinfo/core.py", line 42, in create_client
    raise SystemError('Credentials could not be found.')
SystemError: Credentials could not be found.
```