### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+
+    - name: Tox tests
+      shell: bash
+      # Drop the dot: py3.7 -> py37
+      run: |
+        tox -e py`echo ${{ matrix.python-version }} | tr -d .`

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
           env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
-          dist: xenial
+        - python: 3.8
+          env: TOXENV=py38
         - python: pypy3
           env: TOXENV=pypy3
 

--- a/README.rst
+++ b/README.rst
@@ -118,13 +118,15 @@ Usage
       -t, --timeout INTEGER   Milliseconds. Default: 120000 (2 minutes)
       -l, --limit TEXT        Maximum number of query results. Default: 10
       -d, --days TEXT         Number of days in the past to include. Default: 30
-      -sd, --start-date TEXT  Must be negative. Default: -31
-      -ed, --end-date TEXT    Must be negative. Default: -1
+      -sd, --start-date TEXT  Must be negative or YYYY-MM[-DD]. Default: -31
+      -ed, --end-date TEXT    Must be negative or YYYY-MM[-DD]. Default: -1
+      -m, --month TEXT        Shortcut for -sd & -ed for a single YYYY-MM month.
       -w, --where TEXT        WHERE conditional. Default: file.project = "project"
       -o, --order TEXT        Field to order by. Default: download_count
-      -p, --pip               Only show installs by pip.
+      --all                   Show downloads by all installers, not only pip.
       -pc, --percent          Print percentages.
       -md, --markdown         Output as Markdown.
+      -v, --verbose           Print debug messages to stderr.
       --version               Show the version and exit.
       --help                  Show this message and exit.
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py35,
     py36,
     py37,
+    py38,
     pypy3
 
 [testenv]


### PR DESCRIPTION
Also test on Windows, macOS and Ubuntu using GitHub Actions, with Python 3.5-3.7.

For example:

* https://github.com/hugovk/pypinfo/commit/649224f0da089c80f1469bc3d5dc4536f7f09538/checks?check_suite_id=272725104

Python 3.8 isn't yet available on GHA, but it's tested on Travis CI.

* https://travis-ci.org/hugovk/pypinfo/builds/600265624

And update usage in the README.