### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,5 @@ jobs:
 
     - name: Tox tests
       shell: bash
-      # Drop the dot: py3.7 -> py37
       run: |
-        tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+        tox -e py


### PR DESCRIPTION
* There's no need for the "drop the dot" workaround, it will use the interpreter tox is installed to
* Also test on Python 3.8