### PR TITLE
Test Python 3.9-dev and run slower PyPy3 first, to reduce waiting time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
           env: TOXENV=py37
         - python: 3.8
           env: TOXENV=py38
+        - python: 3.9-dev
+          env: TOXENV=py39
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     include:
         - python: 3.6
           env: TOXENV=lint
+        - python: pypy3
+          env: TOXENV=pypy3
         - python: 3.5
           env: TOXENV=py35
         - python: 3.6
@@ -13,8 +15,6 @@ matrix:
           env: TOXENV=py37
         - python: 3.8
           env: TOXENV=py38
-        - python: pypy3
-          env: TOXENV=pypy3
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py36,
     py37,
     py38,
+    py39,
     pypy3
 
 [testenv]


### PR DESCRIPTION
Python 3.9 is in alpha with official release in October.

---

Move slower PyPy3 to first to make full use of parallel builds and reduce waiting time by about 15s. Not huge, but still :)

# Before

![image](https://user-images.githubusercontent.com/1324225/74589404-cb126a00-500d-11ea-9e26-c21da2ab998a.png)

https://travis-ci.com/ofek/pypinfo/builds/149097142

# After

![image](https://user-images.githubusercontent.com/1324225/74589467-48d67580-500e-11ea-8b79-872db9172b90.png)

https://travis-ci.org/hugovk/pypinfo/builds/650826587
