### PR TITLE
pin tinydb<4, tinyrecord does not yet support tinydb v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ),
     python_requires='>=3.5',
-    install_requires=('appdirs', 'binary', 'click', 'google-cloud-bigquery>=0.29.0', 'tinydb', 'tinyrecord'),
+    install_requires=('appdirs', 'binary', 'click', 'google-cloud-bigquery>=0.29.0', 'tinydb<4', 'tinyrecord'),
     tests_require=['pytest'],
     packages=find_packages(),
     entry_points={'console_scripts': ('pypinfo = pypinfo.cli:pypinfo',)},

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,30 @@
+from pypinfo import db
+
+CREDS_FILE = '/path/to/creds_file.json'
+
+
+def test_get_credentials(tmp_path):
+    # Arrange
+    db.DB_FILE = str(tmp_path / 'db.json')  # Mock
+
+    # Assert
+    assert db.get_credentials() is None
+
+
+def test_set_credentials(tmp_path):
+    # Arrange
+    db.DB_FILE = str(tmp_path / 'db.json')  # Mock
+
+    # Act
+    db.set_credentials(CREDS_FILE)
+
+
+def test_round_trip(tmp_path):
+    # Arrange
+    db.DB_FILE = str(tmp_path / 'db.json')  # Mock
+
+    # Act
+    db.set_credentials(CREDS_FILE)
+
+    # Assert
+    assert db.get_credentials() == CREDS_FILE

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,6 +19,15 @@ def test_set_credentials(tmp_path):
     db.set_credentials(CREDS_FILE)
 
 
+def test_set_credentials_twice(tmp_path):
+    # Arrange
+    db.DB_FILE = str(tmp_path / 'db.json')  # Mock
+
+    # Act
+    db.set_credentials(CREDS_FILE)
+    db.set_credentials(CREDS_FILE)
+
+
 def test_round_trip(tmp_path):
     # Arrange
     db.DB_FILE = str(tmp_path / 'db.json')  # Mock


### PR DESCRIPTION
Fixes https://github.com/ofek/pypinfo/issues/88.

tinyrecord does not yet support the breaking changes in the new tinydb v4 release, and it will take some time for support to be added.

* https://tinydb.readthedocs.io/en/latest/changelog.html#v4-0-0-2020-05-02
* https://tinydb.readthedocs.io/en/latest/upgrade.html#upgrade-v4-0
* https://github.com/eugene-eeo/tinyrecord/issues/11

In the meantime, let's pin to `tinydb<4`.

This also adds simple tests for `db.py`, which[ fail without the pin](https://travis-ci.org/github/hugovk/pypinfo/builds/683406460) and [pass with it](https://travis-ci.org/github/hugovk/pypinfo/builds/683407593).