### PR TITLE
Pass tox CLI positional args through to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     coverage
     pytest
 commands =
-    coverage run --parallel-mode -m pytest
+    coverage run --parallel-mode -m pytest {posargs}
     coverage combine --append
     coverage report -m
 


### PR DESCRIPTION
Allows passing command line arguments such as -x and others to pytest
through the tox entry point.