### PR TITLE
Correct appdirs.user_data_dir() usage

### DIFF
--- a/pypinfo/db.py
+++ b/pypinfo/db.py
@@ -4,7 +4,7 @@ from appdirs import user_data_dir
 from tinydb import TinyDB, Query, where
 from tinyrecord import transaction
 
-DB_FILE = os.path.join(user_data_dir('pypinfo', ''), 'db.json')
+DB_FILE = os.path.join(user_data_dir('pypinfo', appauthor=False), 'db.json')
 
 
 def get_credentials():


### PR DESCRIPTION
Per the appdirs documentation, to disable the appauthor parameter,
should pass False, not the empty string. See:

https://github.com/ActiveState/appdirs/blob/1a6a9da317d88497550d9c79a76bf6b819b17593/appdirs.py#L49-L52

https://github.com/ActiveState/appdirs/blob/1a6a9da317d88497550d9c79a76bf6b819b17593/appdirs.py#L82-L85