### PR TITLE
Clean up ResourceWarning emitted during tests

### DIFF
--- a/pypinfo/db.py
+++ b/pypinfo/db.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 
 from appdirs import user_data_dir
@@ -7,19 +8,26 @@ from tinyrecord import transaction
 DB_FILE = os.path.join(user_data_dir('pypinfo', appauthor=False), 'db.json')
 
 
-def get_credentials():
-    table = TinyDB(DB_FILE, create_dirs=True).table('credentials')
-    query = table.search(Query().path.exists())
+@contextlib.contextmanager
+def get_credentials_table(table=None):
+    if table is None:
+        with TinyDB(DB_FILE, create_dirs=True) as db:
+            yield db.table('credentials')
+    else:
+        yield table
 
-    return query[0]['path'] if query else None
+
+def get_credentials(table=None):
+    with get_credentials_table(table) as table:
+        query = table.search(Query().path.exists())
+        return query[0]['path'] if query else None
 
 
 def set_credentials(creds_file):
-    table = TinyDB(DB_FILE, create_dirs=True).table('credentials')
-    exists = get_credentials()
-
-    with transaction(table) as tr:
-        if exists:
-            tr.update({'path': creds_file}, where('path').exists())
-        else:
-            tr.insert({'path': creds_file})
+    with get_credentials_table() as table:
+        exists = get_credentials(table)
+        with transaction(table) as tr:
+            if exists:
+                tr.update({'path': creds_file}, where('path').exists())
+            else:
+                tr.insert({'path': creds_file})

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -37,3 +37,13 @@ def test_round_trip(tmp_path):
 
     # Assert
     assert db.get_credentials() == CREDS_FILE
+
+
+def test_get_credentials_table(tmp_path):
+    db.DB_FILE = str(tmp_path / 'db.json')
+    with db.get_credentials_table() as table:
+        assert not table._storage._storage._handle.closed
+        with db.get_credentials_table(table) as table2:
+            assert table2 is table
+        assert not table._storage._storage._handle.closed
+    assert table._storage._storage._handle.closed

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     coverage
     pytest
 commands =
-    coverage run --parallel-mode -m pytest {posargs}
+    coverage run --parallel-mode -m pytest -W all {posargs}
     coverage combine --append
     coverage report -m
 


### PR DESCRIPTION
When Python warnings are enabled, these appear as listed below.

To resolve, close the database after use is complete. To avoid opening
and closing the same database twice, the helper get_credentials_table()
was added.

Warnings are now enabled by tox to help catch earlier in the development
process.

    tests/test_db.py::test_get_credentials
      .../pypinfo/tests/test_db.py:11: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_get_credentials0/db.json' mode='r+' encoding='UTF-8'>
        assert db.get_credentials() is None

    tests/test_db.py::test_set_credentials
      .../pypinfo/pypinfo/db.py:19: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_set_credentials0/db.json' mode='r+' encoding='UTF-8'>
        exists = get_credentials()

    tests/test_db.py::test_set_credentials
      .../pypinfo/tests/test_db.py:19: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_set_credentials0/db.json' mode='r+' encoding='UTF-8'>
        db.set_credentials(CREDS_FILE)

    tests/test_db.py::test_set_credentials_twice
    tests/test_db.py::test_set_credentials_twice
      .../pypinfo/pypinfo/db.py:19: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_set_credentials_twice0/db.json' mode='r+' encoding='UTF-8'>
        exists = get_credentials()

    tests/test_db.py::test_set_credentials_twice
      .../pypinfo/tests/test_db.py:27: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_set_credentials_twice0/db.json' mode='r+' encoding='UTF-8'>
        db.set_credentials(CREDS_FILE)

    tests/test_db.py::test_set_credentials_twice
      .../pypinfo/tests/test_db.py:28: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_set_credentials_twice0/db.json' mode='r+' encoding='UTF-8'>
        db.set_credentials(CREDS_FILE)

    tests/test_db.py::test_round_trip
      .../pypinfo/pypinfo/db.py:19: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_round_trip0/db.json' mode='r+' encoding='UTF-8'>
        exists = get_credentials()

    tests/test_db.py::test_round_trip
      .../pypinfo/tests/test_db.py:36: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_round_trip0/db.json' mode='r+' encoding='UTF-8'>
        db.set_credentials(CREDS_FILE)

    tests/test_db.py::test_round_trip
      .../pypinfo/tests/test_db.py:39: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-jon/pytest-63/test_round_trip0/db.json' mode='r+' encoding='UTF-8'>
        assert db.get_credentials() == CREDS_FILE