### PR TITLE
 Upgrade for TinyDB and Tinyrecord

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ install_requires =
     binary
     click
     google-cloud-bigquery >= 0.29.0
-    tinydb < 4
-    tinyrecord
+    tinydb >= 4
+    tinyrecord >= 0.2.0
 packages = find:
 
 [options.entry_points]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,8 +42,8 @@ def test_round_trip(tmp_path):
 def test_get_credentials_table(tmp_path):
     db.DB_FILE = str(tmp_path / 'db.json')
     with db.get_credentials_table() as table:
-        assert not table._storage._storage._handle.closed
+        assert not table._storage._handle.closed
         with db.get_credentials_table(table) as table2:
             assert table2 is table
-        assert not table._storage._storage._handle.closed
-    assert table._storage._storage._handle.closed
+        assert not table._storage._handle.closed
+    assert table._storage._handle.closed


### PR DESCRIPTION
Tinyrecord 0.2.0 has just been released with support for TinyDB 4.

We can now upgrade both, and set minimum required versions to ensure compatibility.

Re:

* https://github.com/eugene-eeo/tinyrecord/issues/11
* https://github.com/ofek/pypinfo/issues/88
* https://github.com/ofek/pypinfo/pull/89