### PR TITLE
Add core tests to increase coverage

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,38 +64,20 @@ def test_normalize_dates_yyy_mm_dd_and_negative_integer():
     assert end_date == -1
 
 
-def test_validate_date_negative_number():
+@pytest.mark.parametrize("test_input", ["-1", "2018-05-15"])
+def test_validate_date_valid(test_input):
     # Act
-    valid = core.validate_date("-1")
+    valid = core.validate_date(test_input)
 
     # Assert
     assert valid
 
 
-def test_validate_date_positive_number():
+@pytest.mark.parametrize("test_input", ["1", "2018-19-39", "something invalid"])
+def test_validate_date_invalid(test_input):
     # Act / Assert
     with pytest.raises(ValueError):
-        core.validate_date("1")
-
-
-def test_validate_date_valid_yyyy_mm_dd():
-    # Act
-    valid = core.validate_date("2018-05-15")
-
-    # Assert
-    assert valid
-
-
-def test_validate_date_invalid_yyyy_mm_dd():
-    # Act
-    with pytest.raises(ValueError):
-        core.validate_date("2018-19-39")
-
-
-def test_validate_date_other_string():
-    # Act / Assert
-    with pytest.raises(ValueError):
-        core.validate_date("something invalid")
+        core.validate_date(test_input)
 
 
 def test_format_date_negative_number():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+from freezegun import freeze_time
 import copy
 import pytest
 
@@ -232,3 +233,54 @@ def test_tabulate_markdown():
 
     # Assert
     assert tabulated == expected
+
+
+@freeze_time("2020-07-14 07:11:49")
+def test_format_json():
+    # Arrange
+    # Data from pycodestyle in 2017-10
+    rows = [
+        ['python_version', 'percent', 'download_count'],
+        ['2.7', '0.54', '587705'],
+        ['3.6', '0.21', '227800'],
+        ['3.5', '0.16', '169851'],
+        ['3.4', '0.078', '84599'],
+        ['3.3', '0.0091', '9953'],
+        ['3.7', '0.0044', '4770'],
+        ['2.6', '0.0041', '4476'],
+        ['3.2', '0.0003', '326'],
+        ['2.8', '3.7e-06', '4'],
+        ['None', '2.8e-06', '3'],
+    ]
+    query_info = {
+        'cached': False,
+        'bytes_processed': 18087095002,
+        'bytes_billed': 18087936000,
+        'estimated_cost': '0.09',
+    }
+    indent = None
+    expected = (
+        '{"last_update":"2020-07-14 07:11:49",'
+        '"query":'
+        '{"bytes_billed":18087936000,'
+        '"bytes_processed":18087095002,'
+        '"cached":false,'
+        '"estimated_cost":"0.09"},'
+        '"rows":['
+        '{"download_count":587705,"percent":"0.54","python_version":"2.7"},'
+        '{"download_count":227800,"percent":"0.21","python_version":"3.6"},'
+        '{"download_count":169851,"percent":"0.16","python_version":"3.5"},'
+        '{"download_count":84599,"percent":"0.078","python_version":"3.4"},'
+        '{"download_count":9953,"percent":"0.0091","python_version":"3.3"},'
+        '{"download_count":4770,"percent":"0.0044","python_version":"3.7"},'
+        '{"download_count":4476,"percent":"0.0041","python_version":"2.6"},'
+        '{"download_count":326,"percent":"0.0003","python_version":"3.2"},'
+        '{"download_count":4,"percent":"3.7e-06","python_version":"2.8"},'
+        '{"download_count":3,"percent":"2.8e-06","python_version":"None"}]}'
+    )
+
+    # Act
+    output = core.format_json(rows, query_info, indent)
+
+    # Assert
+    assert output == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,25 @@ ROWS = [
 ]
 
 
+def test_create_config():
+    # Act
+    config = core.create_config()
+
+    # Assert
+    assert config.use_legacy_sql
+
+
+@pytest.mark.parametrize(
+    "test_input, expected", [("pypinfo", "pypinfo"), ("setuptools_scm", "setuptools-scm"), ("Pillow", "pillow")]
+)
+def test_normalize(test_input, expected):
+    # Act
+    output = core.normalize(test_input)
+
+    # Assert
+    assert output == expected
+
+
 def test_tabulate_default():
     # Arrange
     rows = copy.deepcopy(ROWS)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,156 @@ def test_normalize(test_input, expected):
     assert output == expected
 
 
+def test_normalize_dates_yyy_mm():
+    # Arrange
+    start_date = "2019-03"
+    end_date = "2019-03"
+
+    # Act
+    start_date, end_date = core.normalize_dates(start_date, end_date)
+
+    # Assert
+    assert start_date == "2019-03-01"
+    assert end_date == "2019-03-31"
+
+
+def test_normalize_dates_yyy_mm_dd_and_negative_integer():
+    # Arrange
+    start_date = "2019-03-18"
+    end_date = -1
+
+    # Act
+    start_date, end_date = core.normalize_dates(start_date, end_date)
+
+    # Assert
+    assert start_date == "2019-03-18"
+    assert end_date == -1
+
+
+def test_validate_date_negative_number():
+    # Act
+    valid = core.validate_date("-1")
+
+    # Assert
+    assert valid
+
+
+def test_validate_date_positive_number():
+    # Act / Assert
+    with pytest.raises(ValueError):
+        core.validate_date("1")
+
+
+def test_validate_date_valid_yyyy_mm_dd():
+    # Act
+    valid = core.validate_date("2018-05-15")
+
+    # Assert
+    assert valid
+
+
+def test_validate_date_invalid_yyyy_mm_dd():
+    # Act
+    with pytest.raises(ValueError):
+        core.validate_date("2018-19-39")
+
+
+def test_validate_date_other_string():
+    # Act / Assert
+    with pytest.raises(ValueError):
+        core.validate_date("something invalid")
+
+
+def test_format_date_negative_number():
+    # Arrange
+    dummy_format = "dummy format {}"
+
+    # Act
+    date = core.format_date("-1", dummy_format)
+
+    # Assert
+    assert date == 'DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")'
+
+
+def test_format_date_yyy_mm_dd():
+    # Act
+    date = core.format_date("2018-05-15", core.START_TIMESTAMP)
+
+    # Assert
+    assert date == 'TIMESTAMP("2018-05-15 00:00:00")'
+
+
+def test_month_yyyy_mm():
+    # Act
+    first, last = core.month_ends("2019-03")
+
+    # Assert
+    assert first == "2019-03-01"
+    assert last == "2019-03-31"
+
+
+def test_month_yyyy_mm_dd():
+    # Act / Assert
+    with pytest.raises(ValueError):
+        core.month_ends("2019-03-18")
+
+
+def test_month_negative_integer():
+    # Act / Assert
+    with pytest.raises(AttributeError):
+        core.month_ends(-30)
+
+
+def test_add_percentages():
+    # Arrange
+    rows = [
+        ['python_version', 'download_count'],
+        ['2.7', '480056'],
+        ['3.6', '328008'],
+        ['3.5', '149663'],
+        ['3.4', '36837'],
+        ['3.7', '1883'],
+        ['2.6', '591'],
+        ['3.3', '274'],
+        ['3.2', '10'],
+        ['None', '9'],
+        ['3.8', '2'],
+    ]
+
+    expected = [
+        ['python_version', 'percent', 'download_count'],
+        ['2.7', '48.13%', '480056'],
+        ['3.6', '32.89%', '328008'],
+        ['3.5', '15.01%', '149663'],
+        ['3.4', '3.69%', '36837'],
+        ['3.7', '0.19%', '1883'],
+        ['2.6', '0.06%', '591'],
+        ['3.3', '0.03%', '274'],
+        ['3.2', '0.00%', '10'],
+        ['None', '0.00%', '9'],
+        ['3.8', '0.00%', '2'],
+    ]
+
+    # Act
+    with_percentages = core.add_percentages(rows)
+
+    # Assert
+    assert with_percentages == expected
+
+
+def test_add_download_total():
+    # Arrange
+    rows = copy.deepcopy(ROWS)
+    expected = copy.deepcopy(ROWS)
+    expected.append(["Total", "", "662617"])
+
+    # Act
+    rows_with_total = core.add_download_total(rows)
+
+    # Assert
+    assert rows_with_total == expected
+
+
 def test_tabulate_default():
     # Arrange
     rows = copy.deepcopy(ROWS)
@@ -82,153 +232,3 @@ def test_tabulate_markdown():
 
     # Assert
     assert tabulated == expected
-
-
-def test_validate_date_negative_number():
-    # Act
-    valid = core.validate_date("-1")
-
-    # Assert
-    assert valid
-
-
-def test_validate_date_positive_number():
-    # Act / Assert
-    with pytest.raises(ValueError):
-        core.validate_date("1")
-
-
-def test_validate_date_valid_yyyy_mm_dd():
-    # Act
-    valid = core.validate_date("2018-05-15")
-
-    # Assert
-    assert valid
-
-
-def test_validate_date_invalid_yyyy_mm_dd():
-    # Act
-    with pytest.raises(ValueError):
-        core.validate_date("2018-19-39")
-
-
-def test_validate_date_other_string():
-    # Act / Assert
-    with pytest.raises(ValueError):
-        core.validate_date("somthing invalid")
-
-
-def test_format_date_negative_number():
-    # Arrange
-    dummy_format = "dummy format {}"
-
-    # Act
-    date = core.format_date("-1", dummy_format)
-
-    # Assert
-    assert date == 'DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")'
-
-
-def test_format_date_yyy_mm_dd():
-    # Act
-    date = core.format_date("2018-05-15", core.START_TIMESTAMP)
-
-    # Assert
-    assert date == 'TIMESTAMP("2018-05-15 00:00:00")'
-
-
-def test_month_yyyy_mm():
-    # Act
-    first, last = core.month_ends("2019-03")
-
-    # Assert
-    assert first == "2019-03-01"
-    assert last == "2019-03-31"
-
-
-def test_month_yyyy_mm_dd():
-    # Act / Assert
-    with pytest.raises(ValueError):
-        core.month_ends("2019-03-18")
-
-
-def test_month_negative_integer():
-    # Act / Assert
-    with pytest.raises(AttributeError):
-        core.month_ends(-30)
-
-
-def test_normalize_dates_yyy_mm():
-    # Arrange
-    start_date = "2019-03"
-    end_date = "2019-03"
-
-    # Act
-    start_date, end_date = core.normalize_dates(start_date, end_date)
-
-    # Assert
-    assert start_date == "2019-03-01"
-    assert end_date == "2019-03-31"
-
-
-def test_normalize_dates_yyy_mm_dd_and_negative_integer():
-    # Arrange
-    start_date = "2019-03-18"
-    end_date = -1
-
-    # Act
-    start_date, end_date = core.normalize_dates(start_date, end_date)
-
-    # Assert
-    assert start_date == "2019-03-18"
-    assert end_date == -1
-
-
-def test_add_percentages():
-    # Arrange
-    rows = [
-        ['python_version', 'download_count'],
-        ['2.7', '480056'],
-        ['3.6', '328008'],
-        ['3.5', '149663'],
-        ['3.4', '36837'],
-        ['3.7', '1883'],
-        ['2.6', '591'],
-        ['3.3', '274'],
-        ['3.2', '10'],
-        ['None', '9'],
-        ['3.8', '2'],
-    ]
-
-    expected = [
-        ['python_version', 'percent', 'download_count'],
-        ['2.7', '48.13%', '480056'],
-        ['3.6', '32.89%', '328008'],
-        ['3.5', '15.01%', '149663'],
-        ['3.4', '3.69%', '36837'],
-        ['3.7', '0.19%', '1883'],
-        ['2.6', '0.06%', '591'],
-        ['3.3', '0.03%', '274'],
-        ['3.2', '0.00%', '10'],
-        ['None', '0.00%', '9'],
-        ['3.8', '0.00%', '2'],
-    ]
-
-    # Act
-    with_percentages = core.add_percentages(rows)
-
-    # Assert
-    assert with_percentages == expected
-
-
-def test_add_total():
-    # Arrange
-    rows = copy.deepcopy(ROWS)
-    expected = copy.deepcopy(ROWS)
-    expected.append(["Total", "", "662617"])
-
-    # Act
-    rows_with_total = core.add_download_total(rows)
-
-    # Assert
-    assert rows_with_total == expected

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ passenv = *
 deps =
     codecov
     coverage
+    freezegun
     pytest
 commands =
     coverage run --parallel-mode -m pytest -W all {posargs}


### PR DESCRIPTION
Helps https://github.com/ofek/pypinfo/issues/77.

Also re-order some existing core tests so they're in the same order as the functions they test.

Coverage increases from 78% to 94%.
