### PR TITLE
Add support for libc & libc-version fields

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -37,6 +37,8 @@ from pypinfo.fields import (
     Distro,
     DistroVersion,
     CPU,
+    Libc,
+    LibcVersion,
 )
 
 CONTEXT_SETTINGS = {'max_content_width': 300}
@@ -62,6 +64,8 @@ FIELD_MAP = {
     'distro': Distro,
     'distro-version': DistroVersion,
     'cpu': CPU,
+    'libc': Libc,
+    'libc-version': LibcVersion,
 }
 TIER_COST = 5
 TB = Decimal(TEBIBYTE)
@@ -113,7 +117,8 @@ def pypinfo(
     """Valid fields are:\n
     project | version | file | pyversion | percent3 | percent2 | impl | impl-version |\n
     openssl | date | month | year | country | installer | installer-version |\n
-    setuptools-version | system | system-release | distro | distro-version | cpu
+    setuptools-version | system | system-release | distro | distro-version | cpu |\n
+    libc | libc-version
     """
     if auth:
         set_credentials(auth)

--- a/pypinfo/fields.py
+++ b/pypinfo/fields.py
@@ -29,5 +29,7 @@ SystemRelease = Field('system_release', 'details.system.release')
 Distro = Field('distro_name', 'details.distro.name')
 DistroVersion = Field('distro_version', 'details.distro.version')
 CPU = Field('cpu', 'details.cpu')
+Libc = Field('libc_name', 'details.distro.libc.lib')
+LibcVersion = Field('libc_version', 'details.distro.libc.version')
 
 AGGREGATES = {Percent3, Percent2}


### PR DESCRIPTION
The `libc-version` field is of interest in [manylinux](https://github.com/pypa/manylinux) support and evolution analysis.

From the following data, we can extrapolate what `manylinux` policies are supported, if support is limited by `glibc` or `pip` version.

sample query:
```
Matt$ pypinfo -d 1 --where 'details.distro.libc.lib = "glibc" AND details.installer.name = "pip" AND details.system.name = "Linux"' "" installer-version cpu libc-version
Served from cache: True
Data processed: 0.00 B
Data billed: 0.00 B
Estimated cost: $0.00

| installer_version | cpu    | libc_version | download_count |
| ----------------- | ------ | ------------ | -------------- |
| 20.2.4            | x86_64 | 2.27         |     21,974,762 |
| 20.2.4            | x86_64 | 2.28         |     21,457,215 |
| 19.0.3            | x86_64 | 2.23         |     20,857,445 |
| 20.0.2            | x86_64 | 2.27         |     17,902,167 |
| 20.0.2            | x86_64 | 2.24         |     13,965,686 |
| 9.0.3             | x86_64 | 2.17         |     11,671,024 |
| 20.1.1            | x86_64 | 2.27         |      9,315,956 |
| 20.2.4            | x86_64 | 2.17         |      9,245,599 |
| 20.2.4            | x86_64 | 2.23         |      9,109,112 |
| 20.1.1            | x86_64 | 2.28         |      7,648,007 |
| Total             |        |              |    143,146,973 |
```