### PR TITLE
Remove support for end-of-life Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
           env: TOXENV=lint
         - python: pypy3
           env: TOXENV=pypy3
-        - python: 3.5
-          env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
         - python: 3.7

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -122,11 +122,11 @@ def pypinfo(
     """
     if auth:
         set_credentials(auth)
-        click.echo('Credentials location set to "{}".'.format(get_credentials()))
+        click.echo(f'Credentials location set to "{get_credentials()}".')
         return
 
     if verbose:
-        click.echo('Credentials location set to "{}".'.format(get_credentials()), err=True)
+        click.echo(f'Credentials location set to "{get_credentials()}".', err=True)
 
     if project is None and not fields:
         click.echo(ctx.get_help())
@@ -136,7 +136,7 @@ def pypinfo(
     for field in fields:
         parsed = FIELD_MAP.get(field)
         if parsed is None:
-            raise ValueError('"{}" is an unsupported field.'.format(field))
+            raise ValueError(f'"{field}" is an unsupported field.')
         parsed_fields.append(parsed)
 
     order_name = order
@@ -195,10 +195,10 @@ def pypinfo(
             rows = add_download_total(rows)
 
         if not json:
-            click.echo('Served from cache: {}'.format(from_cache))
-            click.echo('Data processed: {:.2f} {}'.format(processed_amount, processed_unit))
-            click.echo('Data billed: {:.2f} {}'.format(billed_amount, billed_unit))
-            click.echo('Estimated cost: ${}'.format(estimated_cost))
+            click.echo(f'Served from cache: {from_cache}')
+            click.echo(f'Data processed: {processed_amount:.2f} {processed_unit}')
+            click.echo(f'Data billed: {billed_amount:.2f} {billed_unit}')
+            click.echo(f'Estimated cost: ${estimated_cost}')
 
             click.echo()
             click.echo(tabulate(rows, markdown))

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -134,16 +134,16 @@ def build_query(
     query = 'SELECT\n'
 
     for field in fields:
-        query += '  {} as {},\n'.format(field.data, field.name)
+        query += f'  {field.data} as {field.name},\n'
 
     query += FROM.format(start_date, end_date)
 
     if where:
-        query += 'WHERE\n  {}\n'.format(where)
+        query += f'WHERE\n  {where}\n'
     else:
         conditions = []
         if project:
-            conditions.append('file.project = "{}"\n'.format(project))
+            conditions.append(f'file.project = "{project}"\n')
         if pip:
             conditions.append('details.installer.name = "pip"\n')
         if conditions:
@@ -155,13 +155,13 @@ def build_query(
 
         for field in fields[:-1]:
             if field not in AGGREGATES:
-                gb += '  {},\n'.format(field.name)
+                gb += f'  {field.name},\n'
 
         if len(gb) > initial_length:
             query += gb
 
     query += 'ORDER BY\n  {} DESC\n'.format(order or Downloads.name)
-    query += 'LIMIT {}'.format(limit)
+    query += f'LIMIT {limit}'
 
     return query
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -33,7 +32,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     appdirs
     binary

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 1.9
 envlist =
-    py35,
     py36,
     py37,
     py38,


### PR DESCRIPTION
Python 3.5 went end-of-life on 2020-09-30.

Dropping support will reduce overall testing resources when running the
full test matrix.

This allows adopting f-strings to improve readability when formatting
simple strings.

For a complete list of end-of-life Python branches, see:
https://devguide.python.org/devcycle/#end-of-life-branches