### PR TITLE
Drop PyPy3: unsupported by dependency's dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
 
 [options]
 python_requires = >=3.6

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist =
     py36,
     py37,
     py38,
-    py39,
-    pypy3
+    py39
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
The CI is failing on PyPy3: https://github.com/ofek/pypinfo/runs/1385608760

Sub-dependency `google-api-core` depends on `grpcio`.

However, `grpcio` doesn't support PyPy (https://github.com/grpc/grpc/issues/4221) so it's probably easiest just to drop it.