### PR TITLE
perf: use clustered table and standard SQL for lower query costs

### DIFF
--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -133,7 +133,7 @@ def build_query(
 
     query += f'\nWHERE timestamp BETWEEN {start_date} AND {end_date}\n'
     if where:
-        query += f' AND {where}\n'
+        query += f'  AND {where}\n'
     else:
         conditions = []
         if project:
@@ -141,8 +141,8 @@ def build_query(
         if pip:
             conditions.append('details.installer.name = "pip"\n')
         if conditions:
-            query += ' AND '
-            query += ' AND '.join(conditions)
+            query += '  AND '
+            query += '  AND '.join(conditions)
 
     if len(fields) > 1:
         gb = 'GROUP BY\n'
@@ -152,8 +152,9 @@ def build_query(
         for field in fields[:-1]:
             if field not in AGGREGATES:
                 non_aggregate_fields.append(field.name)
+        gb += '  '
         gb += ', '.join(non_aggregate_fields)
-        gb += ' '
+        gb += '\n'
 
         if len(gb) > initial_length:
             query += gb

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -9,15 +9,8 @@ from google.cloud.bigquery.job import QueryJobConfig
 
 from pypinfo.fields import AGGREGATES, Downloads
 
-FROM = """\
-FROM
-  TABLE_DATE_RANGE(
-    [the-psf:pypi.downloads],
-    {},
-    {}
-  )
-"""
-DATE_ADD = 'DATE_ADD(CURRENT_TIMESTAMP(), {}, "day")'
+FROM = 'FROM `the-psf.pypi.file_downloads`'
+DATE_ADD = 'DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL {} DAY)'
 START_TIMESTAMP = 'TIMESTAMP("{} 00:00:00")'
 END_TIMESTAMP = 'TIMESTAMP("{} 23:59:59")'
 START_DATE = '-31'
@@ -27,7 +20,7 @@ DEFAULT_LIMIT = '10'
 
 def create_config():
     config = QueryJobConfig()
-    config.use_legacy_sql = True
+    config.use_legacy_sql = False
     return config
 
 
@@ -136,10 +129,11 @@ def build_query(
     for field in fields:
         query += f'  {field.data} as {field.name},\n'
 
-    query += FROM.format(start_date, end_date)
+    query += FROM
 
+    query += f'\nWHERE timestamp BETWEEN {start_date} AND {end_date}\n'
     if where:
-        query += f'WHERE\n  {where}\n'
+        query += f' AND {where}\n'
     else:
         conditions = []
         if project:
@@ -147,15 +141,19 @@ def build_query(
         if pip:
             conditions.append('details.installer.name = "pip"\n')
         if conditions:
-            query += 'WHERE\n  ' + '  AND '.join(conditions)
+            query += ' AND '
+            query += ' AND '.join(conditions)
 
     if len(fields) > 1:
         gb = 'GROUP BY\n'
         initial_length = len(gb)
 
+        non_aggregate_fields = []
         for field in fields[:-1]:
             if field not in AGGREGATES:
-                gb += f'  {field.name},\n'
+                non_aggregate_fields.append(field.name)
+        gb += ', '.join(non_aggregate_fields)
+        gb += ' '
 
         if len(gb) > initial_length:
             query += gb

--- a/pypinfo/fields.py
+++ b/pypinfo/fields.py
@@ -2,9 +2,9 @@ from collections import namedtuple
 
 Field = namedtuple('Field', ('name', 'data'))
 Downloads = Field('download_count', 'COUNT(*)')
-Date = Field('download_date', 'STRFTIME_UTC_USEC(timestamp, "%Y-%m-%d")')
-Month = Field('download_month', 'STRFTIME_UTC_USEC(timestamp, "%Y-%m")')
-Year = Field('download_year', 'STRFTIME_UTC_USEC(timestamp, "%Y")')
+Date = Field('download_date', 'FORMAT_TIMESTAMP("%Y-%m-%d", timestamp)')
+Month = Field('download_month', 'FORMAT_TIMESTAMP("%Y-%m", timestamp)')
+Year = Field('download_year', 'FORMAT_TIMESTAMP("%Y", timestamp)')
 Country = Field('country', 'country_code')
 Project = Field('project', 'file.project')
 Version = Field('version', 'file.version')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ def test_create_config():
     config = core.create_config()
 
     # Assert
-    assert config.use_legacy_sql
+    assert not config.use_legacy_sql
 
 
 @pytest.mark.parametrize(
@@ -88,7 +88,7 @@ def test_format_date_negative_number():
     date = core.format_date("-1", dummy_format)
 
     # Assert
-    assert date == 'DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")'
+    assert date == 'DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)'
 
 
 def test_format_date_yyy_mm_dd():
@@ -137,17 +137,12 @@ def test_build_query():
 SELECT
   REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)") as python_version,
   COUNT(*) as download_count,
-FROM
-  TABLE_DATE_RANGE(
-    [the-psf:pypi.downloads],
-    TIMESTAMP("2017-10-01 00:00:00"),
-    TIMESTAMP("2017-10-31 23:59:59")
-  )
-WHERE
-  file.project = "pycodestyle"
+FROM `the-psf.pypi.file_downloads`
+WHERE timestamp BETWEEN TIMESTAMP("2017-10-01 00:00:00") AND TIMESTAMP("2017-10-31 23:59:59")
+  AND file.project = "pycodestyle"
   AND details.installer.name = "pip"
 GROUP BY
-  python_version,
+  python_version
 ORDER BY
   download_count DESC
 LIMIT 100


### PR DESCRIPTION
By using the clustered data table, performance if improved because
BigQuery can skip of data that doesn't match the desired project.

Tested locally:

```
$ pypinfo google-cloud-bigquery        Served from cache: False
Data processed: 740.43 MiB
Data billed: 741.00 MiB
Estimated cost: $0.01

| download_count |
| -------------- |
|     10,149,146 |
```

Tested locally with all supported fields:

```
$ pypinfo google-cloud-bigquery project version file pyversion percent3 percent2 impl impl-version openssl date month year country installer installer-version setuptools-version system system-release distro distro-version cpu libc libc-version
Served from cache: False
Data processed: 4.62 GiB
Data billed: 4.62 GiB
Estimated cost: $0.03

| project               | version | file                                              | python_version | percent_3 | percent_2 | implementation | impl_version | openssl_version | download_date | download_month | download_year | country | installer_name | installer_version | setuptools_version | system_name | system_release    | distro_name      | distro_version | cpu    | libc_name | libc_version | download_count |
| --------------------- | ------- | ------------------------------------------------- | -------------- | --------- | --------- | -------------- | ------------ | --------------- | ------------- | -------------- | ------------- | ------- | -------------- | ----------------- | ------------------ | ----------- | ----------------- | ---------------- | -------------- | ------ | --------- | ------------ | -------------- |
| google-cloud-bigquery | 1.24.0  | google_cloud_bigquery-1.24.0-py2.py3-none-any.whl | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.0l          | 2020-12-15    | 2020-12        |         2,020 | US      | pip            | 20.0.2            | 45.1.0             | Linux       | 5.4.49+           | Debian GNU/Linux |              9 | x86_64 | glibc     | 2.24         |        171,636 |
| google-cloud-bigquery | 1.24.0  | google_cloud_bigquery-1.24.0-py2.py3-none-any.whl | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.0l          | 2020-12-13    | 2020-12        |         2,020 | US      | pip            | 20.0.2            | 45.1.0             | Linux       | 5.4.49+           | Debian GNU/Linux |              9 | x86_64 | glibc     | 2.24         |        160,152 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-07    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1092-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        136,529 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-06    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1092-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        133,927 |
| google-cloud-bigquery | 1.24.0  | google_cloud_bigquery-1.24.0-py2.py3-none-any.whl | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.0l          | 2020-12-14    | 2020-12        |         2,020 | US      | pip            | 20.0.2            | 45.1.0             | Linux       | 5.4.49+           | Debian GNU/Linux |              9 | x86_64 | glibc     | 2.24         |        130,400 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-05    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1092-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        129,844 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-09    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1050-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        126,544 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-04    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1092-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        124,986 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2020-12-30    | 2020-12        |         2,020 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1092-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        121,202 |
| google-cloud-bigquery | 2.6.1   | google_cloud_bigquery-2.6.1-py2.py3-none-any.whl  | 3.7            | 100.0     | 0.0       | CPython        | 3.7          | 1.1.1           | 2021-01-10    | 2021-01        |         2,021 | IN      | pip            | 20.0.2            | 45.2.0             | Linux       | 4.15.0-1050-azure | Ubuntu           |          18.04 | x86_64 | glibc     | 2.27         |        121,104 |
| Total                 |         |                                                   |                |           |           |                |              |                 |               |                |               |         |                |                   |                    |             |                   |                  |                |        |           |              |      1,356,324 |
```

Closes #64 