### PR TITLE
update dataset to new Google-hosted location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -338,14 +338,11 @@ Let's use ``--test`` to only see the query instead of sending it.
       file.project as project,
       ROUND(100 * SUM(CASE WHEN REGEXP_EXTRACT(details.python, r"^([^\.]+)") = "3" THEN 1 ELSE 0 END) / COUNT(*), 1) as percent_3,
       COUNT(*) as download_count,
-    FROM
-      TABLE_DATE_RANGE(
-        [the-psf:pypi.downloads],
-        DATE_ADD(CURRENT_TIMESTAMP(), -366, "day"),
-        DATE_ADD(CURRENT_TIMESTAMP(), -1, "day")
-      )
+    FROM `bigquery-public-data.pypi.file_downloads`
+    WHERE timestamp BETWEEN TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -366 DAY) AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)
+      AND details.installer.name = "pip"
     GROUP BY
-      project,
+      project
     ORDER BY
       download_count DESC
     LIMIT 100

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -9,7 +9,7 @@ from google.cloud.bigquery.job import QueryJobConfig
 
 from pypinfo.fields import AGGREGATES, Downloads
 
-FROM = 'FROM `the-psf.pypi.file_downloads`'
+FROM = 'FROM `bigquery-public-data.pypi.file_downloads`'
 DATE_ADD = 'TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {} DAY)'
 START_TIMESTAMP = 'TIMESTAMP("{} 00:00:00")'
 END_TIMESTAMP = 'TIMESTAMP("{} 23:59:59")'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,7 +137,7 @@ def test_build_query():
 SELECT
   REGEXP_EXTRACT(details.python, r"^([^\.]+\.[^\.]+)") as python_version,
   COUNT(*) as download_count,
-FROM `the-psf.pypi.file_downloads`
+FROM `bigquery-public-data.pypi.file_downloads`
 WHERE timestamp BETWEEN TIMESTAMP("2017-10-01 00:00:00") AND TIMESTAMP("2017-10-31 23:59:59")
   AND file.project = "pycodestyle"
   AND details.installer.name = "pip"


### PR DESCRIPTION
Docs updated in https://github.com/pypa/packaging.python.org/pull/831

New location for dataset announced here: https://cloud.google.com/blog/products/open-source/supporting-the-python-ecosystem

I've spot-checked a few packages, and historic data has been imported.