### PR TITLE
CLI: Add -h as help option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,9 @@ Usage
 
       openssl | date | month | year | country | installer | installer-version |
 
-      setuptools-version | system | system-release | distro | distro-version | cpu
+      setuptools-version | system | system-release | distro | distro-version | cpu |
+
+      libc | libc-version
 
     Options:
       -a, --auth TEXT         Path to Google credentials JSON file.
@@ -112,7 +114,7 @@ Usage
       -md, --markdown         Output as Markdown.
       -v, --verbose           Print debug messages to stderr.
       --version               Show the version and exit.
-      --help                  Show this message and exit.
+      -h, --help              Show this message and exit.
 
 pypinfo accepts 0 or more options, followed by exactly 1 project, followed by
 0 or more fields. By default only the last 30 days are queried. Let's take a

--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -41,7 +41,10 @@ from pypinfo.fields import (
     LibcVersion,
 )
 
-CONTEXT_SETTINGS = {'max_content_width': 300}
+CONTEXT_SETTINGS = {
+    'help_option_names': ('-h', '--help'),
+    'max_content_width': 300,
+}
 FIELD_MAP = {
     'project': Project,
     'version': Version,


### PR DESCRIPTION
I often get caught out by the lack of `-h` for help, there's only `--help` by default.

According to the docs, here's how to add `-h` as well:

* https://click.palletsprojects.com/en/8.0.x/documentation/#help-parameter-customization

---

Also, I added Black and Flake8 linting to the CI via pre-commit. It does the same stuff as the tox lint.

Demo:

* https://github.com/hugovk/pypinfo/runs/3394133891?check_suite_focus=true