### PR TITLE
Replace normalize() with  upstream packaging.utils.canonicalize_name

### DIFF
--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -1,11 +1,11 @@
 import calendar
 import json
 import os
-import re
 from datetime import date, datetime
 
 from google.cloud.bigquery import Client
 from google.cloud.bigquery.job import QueryJobConfig
+from packaging.utils import canonicalize_name
 
 from pypinfo.fields import AGGREGATES, Downloads
 
@@ -22,11 +22,6 @@ def create_config():
     config = QueryJobConfig()
     config.use_legacy_sql = False
     return config
-
-
-def normalize(name):
-    """https://www.python.org/dev/peps/pep-0503/#normalized-names"""
-    return re.sub(r'[-_.]+', '-', name).lower()
 
 
 def normalize_dates(start_date, end_date):
@@ -93,7 +88,7 @@ def month_ends(yyyy_mm):
 def build_query(
     project, all_fields, start_date=None, end_date=None, days=None, limit=None, where=None, order=None, pip=None
 ):
-    project = normalize(project)
+    project = canonicalize_name(project)
 
     start_date = start_date or START_DATE
     end_date = end_date or END_DATE

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     binary
     click
     google-cloud-bigquery >= 0.29.0
+    packaging >= 16.2
     platformdirs
     tinydb >= 4
     tinyrecord >= 0.2.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,17 +27,6 @@ def test_create_config():
     assert not config.use_legacy_sql
 
 
-@pytest.mark.parametrize(
-    "test_input, expected", [("pypinfo", "pypinfo"), ("setuptools_scm", "setuptools-scm"), ("Pillow", "pillow")]
-)
-def test_normalize(test_input, expected):
-    # Act
-    output = core.normalize(test_input)
-
-    # Assert
-    assert output == expected
-
-
 def test_normalize_dates_yyy_mm():
     # Arrange
     start_date = "2019-03"


### PR DESCRIPTION
This is the same method used by setuptools and pip. Using the upstream
implementation ensures that pypinfo remains in sync and never drifts
from the reference implementation. The packaging package is likely
already to be instead for one of the many pypa packages.