### PR TITLE
Add type annotations to the project and run mypy on CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+        exclude: ^tests/
+        additional_dependencies: [
+          'click==8.0.1',
+        ]

--- a/pypinfo/db.py
+++ b/pypinfo/db.py
@@ -1,15 +1,17 @@
 import contextlib
 import os
+from typing import Iterator, Optional
 
 from platformdirs import user_data_dir
 from tinydb import TinyDB, Query, where
+from tinydb.table import Table
 from tinyrecord import transaction
 
 DB_FILE = os.path.join(user_data_dir('pypinfo', appauthor=False), 'db.json')
 
 
 @contextlib.contextmanager
-def get_credentials_table(table=None):
+def get_credentials_table(table: Optional[Table] = None) -> Iterator[Table]:
     if table is None:
         with TinyDB(DB_FILE, create_dirs=True) as db:
             yield db.table('credentials')
@@ -17,13 +19,13 @@ def get_credentials_table(table=None):
         yield table
 
 
-def get_credentials(table=None):
+def get_credentials(table: Optional[Table] = None) -> Optional[str]:
     with get_credentials_table(table) as table:
         query = table.search(Query().path.exists())
         return query[0]['path'] if query else None
 
 
-def set_credentials(creds_file):
+def set_credentials(creds_file: str) -> None:
     with get_credentials_table() as table:
         exists = get_credentials(table)
         with transaction(table) as tr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
+
+[tool.mypy]
+pretty = true
+show_error_codes = true
+strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,9 @@ install_requires =
     tinyrecord >= 0.2.0
 packages = find:
 
+[options.package_data]
+pypinfo = py.typed
+
 [options.entry_points]
 console_scripts =
     pypinfo = pypinfo.cli:pypinfo


### PR DESCRIPTION
Type annotations allow for static type checking to build additional
confidence in the correctness of internal and third party APIs. A type
checker, such as mypy can help discover bugs when adding or refactoring
code.

The package distributes a py.typed file for PEP-561 compliance.
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages