### PR TITLE
Fix some ResourceWarnings.

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -165,9 +165,10 @@ def pypinfo(
     )
 
     if run:
-        client = create_client(get_credentials())
-        query_job = client.query(built_query, job_config=create_config())
-        query_rows = query_job.result(timeout=timeout // 1000)
+        with create_client(get_credentials()) as client:
+            query_job = client.query(built_query, job_config=create_config())
+            query_rows = query_job.result(timeout=timeout // 1000)
+            rows = parse_query_result(query_job, query_rows)
 
         # Cached
         from_cache = not not query_job.cache_hit
@@ -185,7 +186,6 @@ def pypinfo(
         estimated_cost = Decimal(TIER_COST * billing_tier) / TB * Decimal(bytes_billed)
         estimated_cost_str = str(estimated_cost.quantize(TO_CENTS, rounding=ROUND_UP))
 
-        rows = parse_query_result(query_job, query_rows)
         if len(rows) == 1 and not json:
             # Only headers returned
             click.echo("No data returned, check project name")

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -51,7 +51,9 @@ def create_client(creds_file: Optional[str] = None) -> Client:
     if creds_file is None:
         raise SystemError('Credentials could not be found.')
 
-    project = json.load(open(creds_file))['project_id']
+    with open(creds_file, encoding="UTF-8") as file:
+        creds = json.load(file)
+    project = creds['project_id']
     return Client.from_service_account_json(creds_file, project=project)
 
 


### PR DESCRIPTION
Before:

```text
$ pypinfo --start-date 2021-01-01 --end-date 2021-01-01 "" pyversion 
/home/mdk/.local/lib/python3.9/site-packages/pypinfo/core.py:54: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/mdk/Downloads/pypi-36125-efb774915fe2.json' mode='r' encoding='UTF-8'>
  project = json.load(open(creds_file))['project_id']
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Served from cache: False
Data processed: 3.33 GiB
Data billed: 3.33 GiB
Estimated cost: $0.02

| python_version | download_count |
| -------------- | -------------- |
| 3.7            |     77,178,709 |
| 3.6            |     29,779,201 |
| 3.8            |     25,137,926 |
| 2.7            |     21,021,703 |
| 3.5            |      5,685,388 |
| 3.9            |      3,881,711 |
| 2.6            |      2,960,821 |
| 3.4            |        318,606 |
| 3.10           |         24,383 |
| 3.3            |          3,788 |
| Total          |    165,992,236 |

sys:1: ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.0.0.13', 39284), raddr=('216.58.204.106', 443)>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
sys:1: ResourceWarning: unclosed <ssl.SSLSocket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.0.0.13', 50468), raddr=('216.58.214.74', 443)>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

After:

```text
$ pypinfo --start-date 2021-01-01 --end-date 2021-01-01 "" pyversion 
Served from cache: False
Data processed: 3.33 GiB
Data billed: 3.33 GiB
Estimated cost: $0.02

| python_version | download_count |
| -------------- | -------------- |
| 3.7            |     77,178,709 |
| 3.6            |     29,779,201 |
| 3.8            |     25,137,926 |
| 2.7            |     21,021,703 |
| 3.5            |      5,685,388 |
| 3.9            |      3,881,711 |
| 2.6            |      2,960,821 |
| 3.4            |        318,606 |
| 3.10           |         24,383 |
| 3.3            |          3,788 |
| Total          |    165,992,236 |
```
