### PR TITLE
Revert "Fix some ResourceWarnings."

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -165,10 +165,9 @@ def pypinfo(
     )
 
     if run:
-        with create_client(get_credentials()) as client:
-            query_job = client.query(built_query, job_config=create_config())
-            query_rows = query_job.result(timeout=timeout // 1000)
-            rows = parse_query_result(query_job, query_rows)
+        client = create_client(get_credentials())
+        query_job = client.query(built_query, job_config=create_config())
+        query_rows = query_job.result(timeout=timeout // 1000)
 
         # Cached
         from_cache = not not query_job.cache_hit
@@ -186,6 +185,7 @@ def pypinfo(
         estimated_cost = Decimal(TIER_COST * billing_tier) / TB * Decimal(bytes_billed)
         estimated_cost_str = str(estimated_cost.quantize(TO_CENTS, rounding=ROUND_UP))
 
+        rows = parse_query_result(query_job, query_rows)
         if len(rows) == 1 and not json:
             # Only headers returned
             click.echo("No data returned, check project name")

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -51,9 +51,7 @@ def create_client(creds_file: Optional[str] = None) -> Client:
     if creds_file is None:
         raise SystemError('Credentials could not be found.')
 
-    with open(creds_file, encoding="UTF-8") as file:
-        creds = json.load(file)
-    project = creds['project_id']
+    project = json.load(open(creds_file))['project_id']
     return Client.from_service_account_json(creds_file, project=project)
 
 


### PR DESCRIPTION
Reverts ofek/pypinfo#123.

Due to this on Python 3.10:

```console
$ pypinfo --start-date 2021-01-01 --end-date 2021-01-01 "" pyversion
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/bin/pypinfo", line 33, in <module>
    sys.exit(load_entry_point('pypinfo', 'console_scripts', 'pypinfo')())
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/core.py", line 1236, in invoke
    return Command.invoke(self, ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/hugo/github/pypinfo/pypinfo/cli.py", line 168, in pypinfo
    with create_client(get_credentials()) as client:
AttributeError: __enter__
```