### PR TITLE
Fix some ResourceWarnings.

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -165,9 +165,10 @@ def pypinfo(
     )
 
     if run:
-        client = create_client(get_credentials())
-        query_job = client.query(built_query, job_config=create_config())
-        query_rows = query_job.result(timeout=timeout // 1000)
+        with create_client(get_credentials()) as client:
+            query_job = client.query(built_query, job_config=create_config())
+            query_rows = query_job.result(timeout=timeout // 1000)
+            rows = parse_query_result(query_job, query_rows)
 
         # Cached
         from_cache = not not query_job.cache_hit
@@ -185,7 +186,6 @@ def pypinfo(
         estimated_cost = Decimal(TIER_COST * billing_tier) / TB * Decimal(bytes_billed)
         estimated_cost_str = str(estimated_cost.quantize(TO_CENTS, rounding=ROUND_UP))
 
-        rows = parse_query_result(query_job, query_rows)
         if len(rows) == 1 and not json:
             # Only headers returned
             click.echo("No data returned, check project name")

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -51,7 +51,9 @@ def create_client(creds_file: Optional[str] = None) -> Client:
     if creds_file is None:
         raise SystemError('Credentials could not be found.')
 
-    project = json.load(open(creds_file))['project_id']
+    with open(creds_file, encoding="UTF-8") as file:
+        creds = json.load(file)
+    project = creds['project_id']
     return Client.from_service_account_json(creds_file, project=project)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.6
 install_requires =
     binary
     click
-    google-cloud-bigquery >= 0.29.0
+    google-cloud-bigquery >= 2.11.0
     packaging >= 16.2
     platformdirs
     tinydb >= 4


### PR DESCRIPTION
references: #123

So the issue with #123 is funny, I just forgot to bump google-cloud-bigquery minimum version in `setup.cfg`.

Without bumping it to the release they introduced the context manager, it could have gone mostly right, there's tens of versions since then.

Sadly back then, they had `python_requires=">=3.6"` and now they have `python_requires=">=3.6, <3.10"`, so when we install `google-cloud-bigquery` with Python 3.10 it forces pip to crawl back to this old version not enforcing `<3.10`, but not having `__enter__` neither.

I enforced the right version in `setup.cfg` but we may not want to merge this as it makes `pypinfo` uninstallable with 3.10 as there does not exist a `google-cloud-bigquery` recent enough *and* compatible with py310 (the irony).

