### PR TITLE
Add tests for core.create_client

### DIFF
--- a/tests/data/sample-credentials.json
+++ b/tests/data/sample-credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "pypinfo-test",
+  "private_key_id": "1234567890qwertyuiop",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp\nwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5\n1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh\n3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2\npIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX\nGukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il\nAkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF\nL0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k\nX6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl\nU9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ\n37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "test@example.com",
+  "client_id": "123456789",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40example.com"
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -53,6 +53,23 @@ def test_normalize_dates_yyy_mm_dd_and_negative_integer():
     assert end_date == -1
 
 
+def test_create_client_file_is_none():
+    # Act / Assert
+    with pytest.raises(SystemError):
+        core.create_client(None)
+
+
+def test_create_client_with_filename():
+    # Arrange
+    filename = "tests/data/sample-credentials.json"
+
+    # Act
+    output = core.create_client(filename)
+
+    # Assert
+    assert output.project == "pypinfo-test"
+
+
 @pytest.mark.parametrize("test_input", ["-1", "2018-05-15"])
 def test_validate_date_valid(test_input):
     # Act


### PR DESCRIPTION
Will help avoid things like https://github.com/ofek/pypinfo/pull/123#issuecomment-951931508.

The sample private key is an example from http://phpseclib.sourceforge.net/rsa/examples.html, I originally tried a dummy value but it does need to be a valid key that can be parsed by `pyasn1_modules`.

Will be useful for https://github.com/ofek/pypinfo/pull/125.