### PR TITLE
Fix 'twine check' errors and warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -346,7 +346,7 @@ Unreleased
 - Add ``-h`` as help option
 - Treat and validate numeric CLI arguments as numbers
 - Replace appdirs with platformdirs
-- Fix ``ResourceWarning``s
+- Fix ResourceWarnings
 
 19.0.0
 ^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = pypinfo
 version = attr: pypinfo.__version__
 description = View PyPI download statistics with ease.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Ofek Lev
 author_email = ofekmeister@gmail.com
 maintainer = Ofek Lev


### PR DESCRIPTION
Fix https://github.com/ofek/pypinfo/pull/129#issuecomment-961411090.

# `master`

```console
$ rm -rf dist
$ python -m build
...
Successfully built pypinfo-20.0.0.tar.gz and pypinfo-20.0.0-py3-none-any.whl
$ twine check --strict dist/*
Checking dist/pypinfo-20.0.0-py3-none-any.whl: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 349: Warning: Inline literal start-string without end-string.
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/pypinfo-20.0.0.tar.gz: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 349: Warning: Inline literal start-string without end-string.
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```

# PR

RST doesn't like code formatting touching non-formatting:
```
Fix ``ResourceWarning``s
```
Let's just remove the formatting.

And let's get rid of those warnings too by specifying `long_description_content_type = text/x-rst`.


```console
$ rm -rf dist
$ python -m build
...
Successfully built pypinfo-20.0.0.tar.gz and pypinfo-20.0.0-py3-none-any.whl
$ twine check --strict dist/*
Checking dist/pypinfo-20.0.0-py3-none-any.whl: PASSED
Checking dist/pypinfo-20.0.0.tar.gz: PASSED
```

