### PR TITLE
Deploy to PyPI for tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'ofek'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: deploy-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python -m build
+          twine check --strict dist/*
+
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Re: https://github.com/ofek/pypinfo/pull/129#issuecomment-961704127

To deploy to prod PyPI, push a tag, for example:

```sh
# Update README release notes and version number as usual and then:
git tag 20.0.0
git push --tags
```

(Doesn't deploy to Test PyPI.)


We may need a bit of iteration, but let's see how this works!