### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,18 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: deploy-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            deploy-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: setup.cfg
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.cfg
 
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black
 
@@ -10,7 +10,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.931
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 ------------
 
 pypinfo is distributed on `PyPI`_ as a universal wheel and is available on
-Linux/macOS and Windows and supports Python 3.6+.
+Linux/macOS and Windows and supports Python 3.7+.
 
 This is relatively painless, I swear.
 

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -171,7 +171,7 @@ def build_query(
         if len(gb) > initial_length:
             query += gb
 
-    query += 'ORDER BY\n  {} DESC\n'.format(order or Downloads.name)
+    query += f'ORDER BY\n  {order or Downloads.name} DESC\n'
     query += f'LIMIT {limit}'
 
     return query
@@ -229,7 +229,7 @@ def tabulate(rows: Rows, markdown: bool = False) -> str:
         for i, item in enumerate(row):
             if item.isdigit():
                 # Separate the thousands
-                rows[r][i] = "{:,}".format(int(item))
+                rows[r][i] = f"{int(item):,}"
                 right_align[r][i] = True
             elif item.endswith('%'):
                 right_align[r][i] = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     binary
     click

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 1.9
 envlist =
-    py36,
     py37,
     py38,
     py39,


### PR DESCRIPTION
Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team and we can drop it whenever the next release is.

https://endoflife.date/python

---

Also a few other updates:

* Use f-strings
* Update pre-commit
* GHA: Cache pip with https://github.com/actions/setup-python instead of https://github.com/actions/cache, can remove some config
* GHA: Add `workflow_dispatch` to allow triggering builds