### PR TITLE
CI: Remove redundant 'python setup.py --version'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Build package
         run: |
-          python setup.py --version
           python -m build
           twine check --strict dist/*
 


### PR DESCRIPTION
No longer required.

Follow on from https://github.com/ofek/pypinfo/pull/134#issuecomment-1030874715.