### PR TITLE
Add support for version matching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -321,6 +321,52 @@ Let's use ``--test`` to only see the query instead of sending it.
       download_count DESC
     LIMIT 100
 
+Downloads for a given version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+pypinfo supports `PEP 440 version matching <https://peps.python.org/pep-0440/#version-matching>`_.
+
+We can use it to query stats on a given major version.
+
+.. code-block:: console
+
+    $ pypinfo -pc 'pip==21.*' pyversion version
+    Served from cache: False
+    Data processed: 34.45 MiB
+    Data billed: 35.00 MiB
+    Estimated cost: $0.01
+
+    | python_version | version | percent | download_count |
+    | -------------- | ------- | ------- | -------------- |
+    | 3.6            | 21.3.1  |  78.74% |         10,430 |
+    | 3.8            | 21.3.1  |   7.81% |          1,034 |
+    | 3.7            | 21.2.1  |   3.59% |            476 |
+    | 3.7            | 21.3.1  |   2.60% |            345 |
+    | 3.7            | 21.0.1  |   2.25% |            298 |
+    | 3.8            | 21.0.1  |   1.58% |            209 |
+    | 3.8            | 21.2.1  |   1.42% |            188 |
+    | 3.7            | 21.1.2  |   0.81% |            107 |
+    | 3.9            | 21.3.1  |   0.69% |             92 |
+    | 3.8            | 21.1.1  |   0.51% |             67 |
+    | Total          |         |         |         13,246 |
+
+We can also use it to query stats on an exact version:
+
+.. code-block:: console
+
+    $ pypinfo -pc 'numpy==1.23rc3' pyversion version
+    Served from cache: False
+    Data processed: 34.01 MiB
+    Data billed: 35.00 MiB
+    Estimated cost: $0.01
+
+    | python_version | version   | percent | download_count |
+    | -------------- | --------- | ------- | -------------- |
+    | 3.9            | 1.23.0rc3 |  63.33% |             38 |
+    | 3.8            | 1.23.0rc3 |  28.33% |             17 |
+    | 3.10           | 1.23.0rc3 |   8.33% |              5 |
+    | Total          |           |         |             60 |
+
 Credits
 -------
 


### PR DESCRIPTION
This allows to gather statistics on specific version of a project.
This implements [PEP 440 version matching](https://peps.python.org/pep-0440/#version-matching).

e.g.

With an exact version:
```
pypinfo % pypinfo 'numpy==1.22.4' file
Served from cache: False
Data processed: 37.83 MiB
Data billed: 38.00 MiB
Estimated cost: $0.01

| file                                                                    | download_count |
| ----------------------------------------------------------------------- | -------------- |
| numpy-1.22.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |          9,291 |
| numpy-1.22.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |          2,379 |
| numpy-1.22.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl |            962 |
| numpy-1.22.4.zip                                                        |            572 |
| numpy-1.22.4-cp310-cp310-win_amd64.whl                                  |            371 |
| numpy-1.22.4-cp39-cp39-win_amd64.whl                                    |            311 |
| numpy-1.22.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl |            153 |
| numpy-1.22.4-cp38-cp38-win_amd64.whl                                    |            135 |
| numpy-1.22.4-cp39-cp39-macosx_10_15_x86_64.whl                          |             80 |
| numpy-1.22.4-cp38-cp38-macosx_10_15_x86_64.whl                          |             74 |
| Total                                                                   |         14,328 |
```


Or with prefix matching:
```

pypinfo % pypinfo  'numpy==1.23.*' file
Served from cache: False
Data processed: 37.83 MiB
Data billed: 38.00 MiB
Estimated cost: $0.01

| file                                                                       | download_count |
| -------------------------------------------------------------------------- | -------------- |
| numpy-1.23.0rc3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |             12 |
| numpy-1.23.0rc3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |              9 |
| numpy-1.23.0rc3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl |              5 |
| numpy-1.23.0rc2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |              4 |
| numpy-1.23.0rc2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   |              3 |
| numpy-1.23.0rc3-cp38-cp38-macosx_11_0_arm64.whl                            |              2 |
| numpy-1.23.0rc3-cp310-cp310-win_amd64.whl                                  |              2 |
| numpy-1.23.0rc2.tar.gz                                                     |              1 |
| numpy-1.23.0rc2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl |              1 |
| Total                                                                      |             39 |
```
