### PR TITLE
Update `--where` not to discard `project` / `installer` filtering

### DIFF
--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -138,20 +138,16 @@ def build_query(
     for field in fields:
         query += f'  {field.data} as {field.name},\n'
 
-    query += FROM
+    query += f'{FROM}\n'
 
-    query += f'\nWHERE timestamp BETWEEN {start_date} AND {end_date}\n'
+    conditions = [f'WHERE timestamp BETWEEN {start_date} AND {end_date}\n']
+    if project:
+        conditions.append(f'file.project = "{project}"\n')
+    if pip:
+        conditions.append('details.installer.name = "pip"\n')
+    query += '  AND '.join(conditions)
     if where:
         query += f'  AND {where}\n'
-    else:
-        conditions = []
-        if project:
-            conditions.append(f'file.project = "{project}"\n')
-        if pip:
-            conditions.append('details.installer.name = "pip"\n')
-        if conditions:
-            query += '  AND '
-            query += '  AND '.join(conditions)
 
     if len(fields) > 1:
         gb = 'GROUP BY\n'


### PR DESCRIPTION
Using `pypinfo numpy` automatically add some `WHERE` clauses to filter on project name and pip installer:
```
WHERE timestamp BETWEEN ...
  AND file.project = "numpy"
  AND details.installer.name = "pip"
```

However, when adding a `--where` argument, pypinfo would not honor the project name & installer filters.
`pypinfo --where 'file.filename LIKE "%manylinux%"' numpy`:
```
WHERE timestamp BETWEEN ...
  AND file.filename LIKE "%manylinux%"
```

Project & installer filtering are now honored when using `--where`.
`pypinfo --where 'file.filename LIKE "%manylinux%"' numpy`:
```
WHERE timestamp BETWEEN ...
  AND file.project = "numpy"
  AND details.installer.name = "pip"
  AND file.filename LIKE "%manylinux%"
```
fix #45 