### PR TITLE
fix: run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
 
@@ -10,7 +10,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.961
     hooks:
       - id: mypy
         exclude: ^tests/


### PR DESCRIPTION
This updates `black` to a version not using an internal detail of `click` which has been removed and breaks CI lint workflows.