### PR TITLE
Add unit test for `pypinfo.core.parse_query_result`

### DIFF
--- a/pypinfo/cli.py
+++ b/pypinfo/cli.py
@@ -168,7 +168,7 @@ def pypinfo(
         with create_client(get_credentials()) as client:
             query_job = client.query(built_query, job_config=create_config())
             query_rows = query_job.result(timeout=timeout // 1000)
-            rows = parse_query_result(query_job, query_rows)
+            rows = parse_query_result(query_rows)
 
         # Cached
         from_cache = not not query_job.cache_hit

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from google.cloud.bigquery import Client
-from google.cloud.bigquery.job import QueryJob, QueryJobConfig
+from google.cloud.bigquery.job import QueryJobConfig
 from google.cloud.bigquery.table import RowIterator
 from packaging.utils import canonicalize_name
 
@@ -170,8 +170,8 @@ def build_query(
     return query
 
 
-def parse_query_result(query_job: QueryJob, query_rows: RowIterator) -> Rows:
-    rows = [[field.name for field in query_job.result().schema]]
+def parse_query_result(query_rows: RowIterator) -> Rows:
+    rows = [[field.name for field in query_rows.schema]]
     rows.extend([str(item) for item in row] for row in query_rows)
     return rows
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,9 @@ from freezegun import freeze_time
 import copy
 import pytest
 
+from google.cloud.bigquery.schema import SchemaField
+from google.cloud.bigquery.table import RowIterator
+
 from pypinfo import core
 from pypinfo.fields import File, PythonVersion
 
@@ -420,3 +423,26 @@ def test_format_json():
 
     # Assert
     assert output == expected
+
+
+def test_parse_query_result():
+    data = [
+        ["name", "other"],
+        ["name1", 1],
+        ["name2", 2],
+    ]
+    expected = [[str(cell) for cell in row] for row in data]
+    schema = (
+        SchemaField(data[0][0], "STRING"),
+        SchemaField(data[0][1], "INTEGER"),
+    )
+
+    class MockRowIterator(RowIterator):
+        def __init__(self):
+            super().__init__(None, None, None, schema)
+
+        def __iter__(self):
+            return iter(tuple(data[1:]))
+
+    actual = core.parse_query_result(MockRowIterator())
+    assert actual == expected


### PR DESCRIPTION
I don't feel very strongly about this test but it will allow to reach 100% coverage in `pypinfo/core.py` (together with #140) which will make it easier to see if we have 100% diff coverage when developing other things locally.