### PR TITLE
Add `__main__.py` to enable `python -m pypinfo`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,11 +6,8 @@ branch = True
 omit =
     pypinfo/cli.py
     pypinfo/keygen.py
+    pypinfo/__main__.py
 
 [report]
 exclude_also =
     if __name__ == .__main__.:
-
-[run]
-omit =
-    **/pypinfo/__main__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,9 @@ omit =
     pypinfo/keygen.py
 
 [report]
-exclude_lines =
-    pragma: no cover
+exclude_also =
     if __name__ == .__main__.:
+
+[run]
+omit =
+    **/pypinfo/__main__.py

--- a/pypinfo/__main__.py
+++ b/pypinfo/__main__.py
@@ -1,0 +1,4 @@
+from pypinfo import cli
+
+if __name__ == "__main__":
+    cli.pypinfo()


### PR DESCRIPTION
This allows you to easily specify which interpreter to use:

```sh
pypinfo --percent -d 1 pillow
python -m pypinfo --percent -d 1 pillow
python3.11 -m pypinfo --percent -d 1 pillow
```
