### PR TITLE
GitHub Actions: upgrade from deprecated `ubuntu-20.04`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'ofek'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
> We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on **2025-02-01** and the image will be fully unsupported by **2025-04-01**.

https://github.com/actions/runner-images/issues/11101

We're using `ubuntu-latest` in the other workflows, let's use that here too.