### PR TITLE
Add `--dry-run` to check how much data would be processed, but don't actually run query

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,36 +23,37 @@ pypinfo is a simple CLI to access [PyPI](https://pypi.org/) download statistics 
 ```console
 $ pypinfo
 Usage: pypinfo [OPTIONS] [PROJECT] [FIELDS]... COMMAND [ARGS]...
-        
-    Valid fields are:
 
-    project | version | file | pyversion | percent3 | percent2 | impl | impl-version |
-  
-    openssl | date | month | year | country | installer | installer-version |
-  
-    setuptools-version | system | system-release | distro | distro-version | cpu |
+  Valid fields are:
 
-    libc | libc-version
-    
+  project | version | file | pyversion | percent3 | percent2 | impl | impl-version |
+
+  openssl | date | month | year | country | installer | installer-version |
+
+  setuptools-version | system | system-release | distro | distro-version | ci | cpu |
+
+  libc | libc-version
+
 Options:
-    -a, --auth TEXT         Path to Google credentials JSON file.
-    --run / --test          --test simply prints the query.
-    -j, --json              Print data as JSON, with keys `rows` and `query`.
-    -i, --indent INTEGER    JSON indentation level.
-    -t, --timeout INTEGER   Milliseconds. Default: 120000 (2 minutes)
-    -l, --limit INTEGER        Maximum number of query results. Default: 10
-    -d, --days INTEGER         Number of days in the past to include. Default: 30
-    -sd, --start-date TEXT  Must be negative or YYYY-MM[-DD]. Default: -31
-    -ed, --end-date TEXT    Must be negative or YYYY-MM[-DD]. Default: -1
-    -m, --month TEXT        Shortcut for -sd & -ed for a single YYYY-MM month.
-    -w, --where TEXT        WHERE conditional. Default: file.project = "project"
-    -o, --order TEXT        Field to order by. Default: download_count
-    --all                   Show downloads by all installers, not only pip.
-    -pc, --percent          Print percentages.
-    -md, --markdown         Output as Markdown.
-    -v, --verbose           Print debug messages to stderr.
-    --version               Show the version and exit.
-    -h, --help              Show this message and exit.
+  -a, --auth TEXT         Path to Google credentials JSON file.
+  --run / --test          --test simply prints the query.
+  -n, --dry-run           Don't run query but display how much data would be processed.
+  -j, --json              Print data as JSON, with keys `rows` and `query`.
+  -i, --indent INTEGER    JSON indentation level.
+  -t, --timeout INTEGER   Milliseconds. Default: 120000 (2 minutes)
+  -l, --limit INTEGER     Maximum number of query results. Default: 10
+  -d, --days INTEGER      Number of days in the past to include. Default: 30
+  -sd, --start-date TEXT  Must be negative or YYYY-MM[-DD]. Default: -31
+  -ed, --end-date TEXT    Must be negative or YYYY-MM[-DD]. Default: -1
+  -m, --month TEXT        Shortcut for -sd & -ed for a single YYYY-MM month.
+  -w, --where TEXT        WHERE conditional. Default: file.project = "project"
+  -o, --order TEXT        Field to order by. Default: download_count
+  --all                   Show downloads by all installers, not only pip.
+  -pc, --percent          Print percentages.
+  -md, --markdown         Output as Markdown.
+  -v, --verbose           Print debug messages to stderr.
+  --version               Show the version and exit.
+  -h, --help              Show this message and exit.
 ```
 
 pypinfo accepts 0 or more options, followed by exactly 1 project, followed by

--- a/pypinfo/core.py
+++ b/pypinfo/core.py
@@ -26,9 +26,12 @@ DEFAULT_LIMIT = 10
 Rows = list[list[str]]
 
 
-def create_config() -> QueryJobConfig:
+def create_config(dry_run: bool = False) -> QueryJobConfig:
     config = QueryJobConfig()
     config.use_legacy_sql = False
+    if dry_run:
+        config.dry_run = True
+        config.use_query_cache = False
     return config
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,7 +33,17 @@ def test_create_config() -> None:
     config = core.create_config()
 
     # Assert
+    assert not config.dry_run
     assert not config.use_legacy_sql
+
+
+def test_create_config_dry_run() -> None:
+    # Act
+    config = core.create_config(dry_run=True)
+
+    # Assert
+    assert config.dry_run
+    assert not config.use_query_cache
 
 
 def test_normalize_dates_yyy_mm() -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ deps =
 commands =
     coverage run --parallel-mode -m pytest -W all {posargs}
     coverage combine --append
-    coverage report -m
+    coverage report --show-missing
+    coverage html
     coverage xml
 
 [testenv:lint]


### PR DESCRIPTION
Here's how to run a dry-run query to see how much data would be processed by a given command's query, by adding `dry_run=True, use_query_cache=False` to the config:

https://cloud.google.com/bigquery/docs/samples/bigquery-query-dry-run#bigquery_query_dry_run-python

Let's expose it with the `--dry-run` option.

## Dry run

```console
❯ pypinfo --dry-run --all --days 1 --percent pillow pyversion
Served from cache: False
Data processed: 179.27 MiB
Data billed: 0.00 B
Estimated cost: $0.00
```
```console
❯ pypinfo --dry-run --all --days 1 --percent --json pillow pyversion
{"last_update":"2025-04-29 12:49:20","query":{"bytes_billed":0,"bytes_processed":187974046,"cached":false,"estimated_cost":"0.00"},"rows":[]}
```

## Real run

```console
❯ pypinfo --all --days 1 --percent pillow pyversion
Served from cache: False
Data processed: 179.27 MiB
Data billed: 180.00 MiB
Estimated cost: $0.01

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 3.11           |  21.14% |        885,918 |
| 3.12           |  17.61% |        738,188 |
| 3.10           |  17.24% |        722,728 |
| 3.9            |  13.72% |        574,983 |
| 3.7            |  10.09% |        423,114 |
| 3.8            |   6.99% |        292,813 |
| 3.13           |   6.58% |        275,766 |
| None           |   4.99% |        209,134 |
| 3.6            |   1.41% |         58,972 |
| 2.7            |   0.24% |          9,901 |
| Total          |         |      4,191,517 |

```
```console
❯ pypinfo --all --days 1 --percent --json pillow pyversion
{"last_update":"2025-04-29 12:49:45","query":{"bytes_billed":188743680,"bytes_processed":187974046,"cached":false,"estimated_cost":"0.01"},"rows":[{"download_count":885960,"percent":"0.21","python_version":"3.11"},{"download_count":738283,"percent":"0.18","python_version":"3.12"},{"download_count":722784,"percent":"0.17","python_version":"3.10"},{"download_count":575054,"percent":"0.14","python_version":"3.9"},{"download_count":423088,"percent":"0.1","python_version":"3.7"},{"download_count":292835,"percent":"0.07","python_version":"3.8"},{"download_count":275799,"percent":"0.066","python_version":"3.13"},{"download_count":209172,"percent":"0.05","python_version":"None"},{"download_count":58961,"percent":"0.014","python_version":"3.6"},{"download_count":9899,"percent":"0.0024","python_version":"2.7"}]}
```