### PR TITLE
Add zizmor to pre-commit and fix findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   deploy:
     if: github.repository_owner == 'ofek'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,19 +8,24 @@ on:
     - '*'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   deploy:
     if: github.repository_owner == 'ofek'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
-          cache: pip
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  use-trusted-publishing:
+    ignore:
+      - deploy.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
       - id: black
 
@@ -9,8 +9,13 @@ repos:
     hooks:
       - id: flake8
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v1.20.2
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
We're not using Trusted Publishers yet:

```
  info[use-trusted-publishing]: prefer trusted publishing for authentication
    --> .github/workflows/deploy.yml:42:9
     |
  42 |         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
  ...
  45 |           password: ${{ secrets.PYPI_API_TOKEN }}
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uses a manually-configured credential instead of Trusted Publishing
     |
     = note: audit confidence → High
```

This is only an informational finding, so I've ignored it for now. We should switch over at some point, which requires some minimal config for the project on PyPI.
